### PR TITLE
feat: filter out non-in-project components

### DIFF
--- a/.changeset/rich-pears-sneeze.md
+++ b/.changeset/rich-pears-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+filter out non-in-project components

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,9 +8,6 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "rules": {
-    "@typescript-eslint/no-explicit-any": 0,
-    "@typescript-eslint/no-non-null-assertion": 0,
-    "@typescript-eslint/ban-ts-comment": 0,
-    "no-mixed-spaces-and-tabs": 0
+    "@typescript-eslint/no-explicit-any": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,24 +15,24 @@
     "lint": "pnpm eslint . --ext .ts,.tsx --ignore-pattern='/playground/*'",
     "format": "prettier --write '**/*.{vue,ts,tsx,json,md}'",
     "postinstall": "simple-git-hooks",
-    "release": "run-s build changeset:publish",
+    "release": "run-s build publish:ci",
     "test": "turbo run test",
     "check": "tsc --noEmit && turbo run check --filter @open-editor/* --log-order grouped",
-    "versions": "run-s changeset:version format",
-    "changeset:version": "changeset version",
-    "changeset:publish": "changeset publish"
+    "versions": "run-s version:ci format",
+    "version:ci": "changeset version",
+    "publish:ci": "changeset publish"
   },
   "engines": {
     "node": ">=16.19.1"
   },
   "packageManager": "pnpm@8.6.11",
   "keywords": [
-    "webpack-plugin",
     "rollup-plugin",
-    "vue-devtools",
-    "react-devtools",
     "vite-plugin",
-    "next-devtools"
+    "webpack-plugin",
+    "next-devtools",
+    "react-devtools",
+    "vue-devtools"
   ],
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",
@@ -40,6 +40,9 @@
     "@open-editor/client": "workspace:*",
     "@open-editor/server": "workspace:*",
     "@open-editor/shared": "workspace:*",
+    "@open-editor/rollup": "workspace:*",
+    "@open-editor/vite": "workspace:*",
+    "@open-editor/webpack": "workspace:*",
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@types/minimist": "^1.2.2",

--- a/packages/client/src/resolve/framework/react15.ts
+++ b/packages/client/src/resolve/framework/react15.ts
@@ -1,7 +1,7 @@
 import { isFunc } from '@open-editor/shared';
 
-import { ResolveDebug } from '../resolveDebug';
-import { ElementSourceMeta } from '../resolveSource';
+import type { ResolveDebug } from '../resolveDebug';
+import type { ElementSourceMeta } from '../resolveSource';
 import { isValidFileName } from '../util';
 import { resolveSourceFromFiber } from './react18';
 

--- a/packages/client/src/resolve/framework/react18.ts
+++ b/packages/client/src/resolve/framework/react18.ts
@@ -1,8 +1,8 @@
 import type { Fiber } from 'react-reconciler';
 import { isFunc } from '@open-editor/shared';
 
-import { ResolveDebug } from '../resolveDebug';
-import { ElementSourceMeta } from '../resolveSource';
+import type { ResolveDebug } from '../resolveDebug';
+import type { ElementSourceMeta } from '../resolveSource';
 import { isValidFileName } from '../util';
 
 export function resolveReact18(

--- a/packages/client/src/resolve/util.ts
+++ b/packages/client/src/resolve/util.ts
@@ -31,7 +31,7 @@ export function hasVueSource(element: HTMLElement) {
   }
 
   while (element) {
-    if (element.getAttribute('__source') != null) {
+    if (getElementVueSource(element) != null) {
       return (hvs = true);
     }
 
@@ -41,10 +41,14 @@ export function hasVueSource(element: HTMLElement) {
   return (hvs = false);
 }
 
+export function getElementVueSource(element: HTMLElement) {
+  return element.getAttribute('__source');
+}
+
 export function parseVueSource(__source: string) {
   const [file, line, column] = __source.split(':');
   return {
-    file,
+    file: ensureFileName(file),
     line: Number(line),
     column: Number(column),
   };

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -92,8 +92,7 @@ export default class OpenEditorPlugin {
     }
 
     if (!entry || !isObj(entry)) {
-      // @ts-ignore
-      entry = [].concat(entry);
+      entry = [].concat(entry) as unknown as webpack.EntryNormalized;
     }
 
     if (Array.isArray(entry)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,12 +16,21 @@ importers:
       '@open-editor/client':
         specifier: workspace:*
         version: link:packages/client
+      '@open-editor/rollup':
+        specifier: workspace:*
+        version: link:packages/rollup
       '@open-editor/server':
         specifier: workspace:*
         version: link:packages/server
       '@open-editor/shared':
         specifier: workspace:*
         version: link:packages/shared
+      '@open-editor/vite':
+        specifier: workspace:*
+        version: link:packages/vite
+      '@open-editor/webpack':
+        specifier: workspace:*
+        version: link:packages/webpack
       '@rollup/plugin-commonjs':
         specifier: ^25.0.4
         version: 25.0.4(rollup@3.28.1)
@@ -397,12 +406,6 @@ importers:
       unplugin-vue-source:
         specifier: 0.0.1-beta.0
         version: 0.0.1-beta.0
-
-  vue-element-plus-admin:
-    dependencies:
-      '@open-editor/vite':
-        specifier: ^0.0.14
-        version: link:../packages/vite
 
 packages:
   /@aashutoshrathi/word-wrap@1.2.6:


### PR DESCRIPTION
The components in `node_modules` are now queried by `__source`, so ignore them for now.