### PR TITLE
fix: `resolveVueSourceAnchor` result out of component scope

### DIFF
--- a/.changeset/eight-shoes-divide.md
+++ b/.changeset/eight-shoes-divide.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+fix `resolveVueSourceAnchor` result out of component scope

--- a/.changeset/tender-elephants-guess.md
+++ b/.changeset/tender-elephants-guess.md
@@ -2,4 +2,4 @@
 '@open-editor/shared': patch
 ---
 
-add type util 'isBol'
+add type util `isBol`

--- a/packages/client/src/resolve/createVueResolver.ts
+++ b/packages/client/src/resolve/createVueResolver.ts
@@ -74,22 +74,23 @@ function resolveVueSourceAnchor<T = any>(
 
   let instance = debug.value;
   let element = debug.originalElement;
+  let __source: string | null | undefined;
 
-  while (element && !isStr(getElementVueSource(element))) {
+  // find the first element with __source
+  while (element && !isStr((__source = getElementVueSource(element)))) {
     element = element.parentElement!;
   }
 
-  const __source = getElementVueSource(element);
-  if (isStr(__source)) {
-    return <const>[instance, parseVueSource(__source)];
+  // if the element exists and belongs to the component, the result is returned
+  if ((<any>element)?.[debug.key] === instance) {
+    return <const>[instance, parseVueSource(__source!)];
   }
 
+  // try to get the result from the component
   while (instance) {
-    const __source = getVueSource(instance);
-    if (isStr(__source)) {
+    if (isStr((__source = getVueSource(instance)))) {
       return <const>[getNext(instance), parseVueSource(__source)];
     }
-
     instance = getNext(instance);
   }
 


### PR DESCRIPTION
Let's say I have such a component in my `node_modules`

```html
<script>
export default {
  name: 'Hello',
}
</script>

<template>
  <div>hello</div>
</template>
```

And then my page looks like this

```html
<script>
import Hello from 'hello';
</script>

<template>
  <div>
    <Hello> word
  </div> 
</template>
```

When I clicked hello, I was directed here

![WX20230922-182540@2x](https://github.com/zjxxxxxxxxx/open-editor/assets/43126836/f119d81b-73fb-4f66-a6b5-c750d2cac513)

It should actually be positioned here

![WX20230922-182554@2x](https://github.com/zjxxxxxxxxx/open-editor/assets/43126836/1d080299-0703-4aed-bc9f-9aac750c0661)


