### PR TITLE
fix: vue2 fail to find component

### DIFF
--- a/.changeset/seven-dots-flow.md
+++ b/.changeset/seven-dots-flow.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+fix vue2 fail to find component

--- a/packages/client/src/elements/defineOverlayElement.ts
+++ b/packages/client/src/elements/defineOverlayElement.ts
@@ -28,6 +28,9 @@ const CSS = `
   pointer-events: none;
   will-change: width, height, top, left;
 }
+.posttion div {
+  will-change: border;
+}
 .margin {
   border: 0px solid var(--overlay-margin);
 }

--- a/packages/client/src/resolve/framework/vue2.ts
+++ b/packages/client/src/resolve/framework/vue2.ts
@@ -8,19 +8,15 @@ function createResolver() {
     isValid: (instance) => Boolean(instance?.$vnode),
     isValidNext: (instance) => Boolean(instance.$parent?.$vnode),
     getNext: (instance) => instance.$parent,
-    getVueSource(instance) {
-      const { $props } = instance.$vnode.componentInstance;
-      return $props?.__source;
-    },
-    getFile(instance) {
-      const { Ctor } = instance.$vnode.componentOptions;
-      return Ctor?.__file ?? Ctor.options?.__file;
-    },
-    getName(instance) {
-      const { Ctor } = instance.$vnode.componentOptions;
-      return Ctor.options?.name;
-    },
+    getSource: (instance) => instance.$props?.__source,
+    getFile: (instance) =>
+      getCtor(instance).__file ?? getCtor(instance).options?.__file,
+    getName: (instance) => getCtor(instance).options?.name,
   });
+
+  function getCtor(instance: any) {
+    return instance.$vnode.componentOptions.Ctor;
+  }
 }
 
 export function resolveVue2(
@@ -28,8 +24,9 @@ export function resolveVue2(
   tree: Partial<ElementSourceMeta>[],
   deep = false,
 ) {
-  if (debug.value._vnode.componentInstance) {
-    debug.value = debug.value._vnode.componentInstance;
+  const componentInstance = debug.value._vnode.componentInstance;
+  if (componentInstance) {
+    debug.value = componentInstance;
   }
 
   if (!resolver) createResolver();

--- a/packages/client/src/resolve/framework/vue3.ts
+++ b/packages/client/src/resolve/framework/vue3.ts
@@ -9,7 +9,7 @@ function createResolver() {
     isValid: (instance) => Boolean(instance),
     isValidNext: (instance) => Boolean(instance.parent),
     getNext: (instance) => instance.parent,
-    getVueSource: (instance) => <string>instance.props.__source,
+    getSource: (instance) => <string>instance.props.__source,
     getFile: (instance) => <string>instance.type.__file,
     getName: (instance) => instance.type.name ?? instance.type.__name,
   });

--- a/playground/rollup-vue2/src/components/Notes.vue
+++ b/playground/rollup-vue2/src/components/Notes.vue
@@ -1,3 +1,11 @@
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name: 'Notes',
+});
+</script>
+
 <template>
   <div>
     <p>


### PR DESCRIPTION
In vue2, where lookups fail if no component instance is mounted on an element, elements without a component instance are now directly attributed to the component instance of an ancestor element.