### PR TITLE
fix: posY initialization out of screen scope

### DIFF
--- a/.changeset/moody-bobcats-doubt.md
+++ b/.changeset/moody-bobcats-doubt.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+fix posY initialization out of screen scope

--- a/packages/client/src/elements/defineOverlayElement.ts
+++ b/packages/client/src/elements/defineOverlayElement.ts
@@ -11,6 +11,7 @@ import {
   on,
   off,
 } from '../utils/document';
+import { create_RAF } from '../utils/createRAF';
 import { InternalElements } from '../constants';
 import type { HTMLTooltipElement } from './defineTooltipElement';
 
@@ -119,24 +120,13 @@ export function defineOverlayElement() {
       this.#update_RAF();
     };
 
-    #last_RAF?: number;
-    #update_RAF = () => {
-      if (this.#last_RAF) {
-        cancelAnimationFrame(this.#last_RAF);
-      }
-      this.#last_RAF = requestAnimationFrame(() => {
-        this.#last_RAF = undefined;
-        this.#update();
-      });
-    };
-
-    #update() {
+    #update_RAF = create_RAF(() => {
       const styles = this.#activeElement
         ? getComputedStyles(this.#activeElement)
         : emptyComputedStyles;
       this.#updateStyles(styles);
       this.#tooltip.update(this.#activeElement, styles.posttion);
-    }
+    });
 
     #updateStyles(styles: Record<string, ComputedStyle>) {
       applyStyle(this.#posttion, {

--- a/packages/client/src/utils/createRAF.ts
+++ b/packages/client/src/utils/createRAF.ts
@@ -1,0 +1,14 @@
+const empty_RAF = -1;
+
+export function create_RAF<T extends (...args: any[]) => any>(callback: T) {
+  let last_RAF = empty_RAF;
+  return function call_RAF(...args: Parameters<T>) {
+    if (last_RAF !== empty_RAF) {
+      cancelAnimationFrame(last_RAF);
+    }
+    last_RAF = requestAnimationFrame(() => {
+      last_RAF = empty_RAF;
+      callback(...args);
+    });
+  };
+}


### PR DESCRIPTION
A smaller initial browser window size causes posY to go out of the screen.