### PR TITLE
fix: prevents long presses from accidentally triggering click events

### DIFF
--- a/.changeset/nasty-dancers-hang.md
+++ b/.changeset/nasty-dancers-hang.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+prevents long presses from accidentally triggering click events

--- a/packages/client/src/elements/defineInspectElement.ts
+++ b/packages/client/src/elements/defineInspectElement.ts
@@ -1,5 +1,6 @@
 import { applyAttrs, create, on, off, append } from '../utils/document';
 import { isValidElement } from '../utils/element';
+import { createStyleInject } from '../utils/createStyleInject';
 import { setupListenersOnWindow } from '../utils/setupListenersOnWindow';
 import { openEditor } from '../utils/openEditor';
 import { InternalElements, Theme, captureOpts } from '../constants';
@@ -27,13 +28,23 @@ const CSS = `
 }
 `;
 
+const resetCSS = `
+* {
+  cursor: default !important;
+  user-select: none !important;
+  -webkit-user-select: none !important;
+  -webkit-touch-callout: none !important;
+}
+`;
+
 export function defineInspectElement() {
+  const resetStyle = createStyleInject(resetCSS);
+
   class InspectElement extends HTMLElement implements HTMLInspectElement {
     #overlay: HTMLOverlayElement;
     #tree: HTMLTreeElement;
     #toggle?: HTMLToggleElement;
     #pointer!: PointerEvent;
-    #resetStyle!: HTMLStyleElement;
 
     #__active__!: boolean;
     get #active() {
@@ -144,7 +155,7 @@ export function defineInspectElement() {
           onOpenEditor: this.#openEditor,
           onExitInspect: this.#cleanupHandlers,
         });
-        this.#appendResetStyle();
+        resetStyle.insert();
       }
     }
 
@@ -156,29 +167,9 @@ export function defineInspectElement() {
         this.#overlay.close();
         this.#tree.close();
         this.#cleanupListenersOnWindow();
-        this.#removeResetStyle();
+        resetStyle.remove();
       }
     };
-
-    #appendResetStyle() {
-      if (!this.#resetStyle) {
-        this.#resetStyle = create('style');
-        this.#resetStyle.innerHTML = `
-          * {
-            cursor: default !important;
-            user-select: none !important;
-            -webkit-user-select: none !important;
-            -webkit-touch-callout: none !important;
-          }
-        `;
-      }
-
-      append(document.body, this.#resetStyle);
-    }
-
-    #removeResetStyle() {
-      this.#resetStyle.remove();
-    }
 
     #openEditor = (element: HTMLElement) => {
       const { meta } = resolveSource(element);

--- a/packages/client/src/utils/createStyleInject.ts
+++ b/packages/client/src/utils/createStyleInject.ts
@@ -1,0 +1,23 @@
+import { append, create } from './document';
+
+export function createStyleInject(css: string, target = document.body) {
+  let style: HTMLStyleElement;
+
+  function insert() {
+    if (!style) {
+      style = create('style');
+      style.innerHTML = css;
+    }
+
+    append(target, style);
+  }
+
+  function remove() {
+    style?.remove();
+  }
+
+  return {
+    insert,
+    remove,
+  };
+}

--- a/packages/client/src/utils/document.ts
+++ b/packages/client/src/utils/document.ts
@@ -38,8 +38,8 @@ export function on(
   listener: (ev: any) => void,
   options?: AddEventListenerOptions & { target?: any },
 ): void;
-export function on(type: any, listener: any, rawOptions: any = {}) {
-  const { target = window, ...options } = rawOptions;
+export function on(type: any, listener: any, rawOpts: any = {}) {
+  const { target = window, ...options } = rawOpts;
   target.addEventListener(type, listener, options);
 }
 
@@ -53,8 +53,8 @@ export function off(
   listener: (ev: any) => void,
   options?: EventListenerOptions & { target?: any },
 ): void;
-export function off(type: any, listener: any, rawOptions: any = {}) {
-  const { target = window, ...options } = rawOptions;
+export function off(type: any, listener: any, rawOpts: any = {}) {
+  const { target = window, ...options } = rawOpts;
   target.removeEventListener(type, listener, options);
 }
 

--- a/packages/client/src/utils/setupListenersOnWindow.ts
+++ b/packages/client/src/utils/setupListenersOnWindow.ts
@@ -94,6 +94,7 @@ export function setupListenersOnWindow(options: SetupHandlersOptions) {
 
   function onClick(event: PointerEvent) {
     onSilence(event);
+
     const element = <HTMLElement>event.target;
     if (element === holdElement) {
       if (event.metaKey) {


### PR DESCRIPTION
Prevent the display of the component tree by long press, which accidentally triggers the click event