### PR TITLE
fix: bug where webpack4 could not import .mjs

### DIFF
--- a/.changeset/funny-shrimps-laugh.md
+++ b/.changeset/funny-shrimps-laugh.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/webpack': patch
+---
+
+fix bug where webpack4 could not import '.mjs'

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -53,6 +53,12 @@ export default class OpenEditorPlugin {
         }).apply(compiler);
       });
     } else {
+      compiler.options.module.rules.push({
+        test: /\.mjs$/,
+        type: 'javascript/auto',
+        include: /node_modules/,
+      });
+
       const entry = compiler.options.entry;
       compiler.options.entry = () =>
         this.resolveClientRuntime((clientRuntimeEntry) => {


### PR DESCRIPTION
@open-editor/webpack add

```ts
compiler.options.module.rules.push({
  test: /\.mjs$/,
  type: 'javascript/auto',
  include: /node_modules/,
});
```