### PR TITLE
fix: non-strict dev environment restrictions

### DIFF
--- a/.changeset/selfish-queens-brush.md
+++ b/.changeset/selfish-queens-brush.md
@@ -1,0 +1,8 @@
+---
+'@open-editor/webpack': patch
+'@open-editor/rollup': patch
+'@open-editor/shared': patch
+'@open-editor/vite': patch
+---
+
+non-strict dev environment restrictions

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ At this time, click element to automatically open the location of the source cod
 
 <img width="500" src="./public/open-editor-demo.png" alt="open editor demo"/>
 
-At this time, you can also choose not to click on the element, but long press (shortcut key: ⌨️ <kbd>command ⌘</kbd> + 🖱 click) the element to view the complete component tree information.
+At this time, you can also choose to long press (shortcut key: ⌨️<kbd>command⌘</kbd>+🖱click) element to view the complete component tree information.
 
 <img width="500" src="./public/open-tree-demo.png" alt="open editor demo"/>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ npm run dev
 
 <img width="500" src="./public/open-editor-demo.png" alt="open editor demo"/>
 
-此时也可以选择不点击元素，而是长按（快捷键：⌨️ <kbd>command ⌘</kbd> + 🖱 click）元素查看完整组件树信息。
+此时也可以选择长按（快捷键：⌨️ <kbd>command ⌘</kbd> + 🖱 click）元素查看完整组件树信息。
 
 <img width="500" src="./public/open-tree-demo.png" alt="open editor demo"/>
 

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'rollup';
 import { resolve } from 'node:path';
-import { createRuntime } from '@open-editor/shared/node';
+import { createRuntime, isDev } from '@open-editor/shared/node';
 import { isObj, isStr } from '@open-editor/shared';
 import { setupServer } from '@open-editor/server';
 
@@ -31,9 +31,7 @@ export interface Options {
 export default function openEditorPlugin(
   options: Options = {},
 ): Plugin | undefined {
-  if (process.env.NODE_ENV !== 'development') {
-    return;
-  }
+  if (!isDev()) return;
 
   const {
     rootDir = process.cwd(),

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -1,0 +1,4 @@
+export function isDev() {
+  const env = process.env.NODE_ENV;
+  return !env || env === 'development';
+}

--- a/packages/shared/src/node.ts
+++ b/packages/shared/src/node.ts
@@ -1,2 +1,3 @@
 export * from './resolve';
 export * from './createRuntime';
+export * from './env';

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'vite';
 import { readFileSync } from 'node:fs';
 import { ServerApis } from '@open-editor/shared';
-import { createRuntime } from '@open-editor/shared/node';
+import { createRuntime, isDev } from '@open-editor/shared/node';
 import { openEditorMiddleware } from '@open-editor/server';
 
 export interface Options {
@@ -31,9 +31,7 @@ export interface Options {
 export default function openEditorPlugin(
   options: Options = {},
 ): Plugin | undefined {
-  if (process.env.NODE_ENV !== 'development') {
-    return;
-  }
+  if (!isDev()) return;
 
   const {
     rootDir = process.cwd(),

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -1,5 +1,5 @@
 import type webpack from 'webpack';
-import { createRuntime } from '@open-editor/shared/node';
+import { createRuntime, isDev } from '@open-editor/shared/node';
 import { isFunc, isObj } from '@open-editor/shared';
 import { setupServer } from '@open-editor/server';
 
@@ -40,9 +40,7 @@ export default class OpenEditorPlugin {
   }
 
   apply(compiler: webpack.Compiler) {
-    if (process.env.NODE_ENV !== 'development') {
-      return;
-    }
+    if (!isDev()) return;
 
     this.compiler = compiler;
 


### PR DESCRIPTION
Treat `process.env.NODE_ENV === undefined` as a development environment