### PR TITLE
feat: Add option `once`

### DIFF
--- a/.changeset/plenty-lemons-press.md
+++ b/.changeset/plenty-lemons-press.md
@@ -1,0 +1,8 @@
+---
+'@open-editor/webpack': patch
+'@open-editor/client': patch
+'@open-editor/rollup': patch
+'@open-editor/vite': patch
+---
+
+Add option `once`

--- a/README.md
+++ b/README.md
@@ -86,21 +86,21 @@ First you need to get the project running.
 npm run dev
 ```
 
-Then open the local server address of the project in the browser. At this time, you can see a toggle button appearing in the upper right corner of the browser. This toggle button can be used to toggle the enabled state of the Element Inspector.
+At this time, open the local server address of the project in the browser, and you will see a toggle button appearing in the upper right corner of the browser. This toggle button can be used to toggle the enabled status of the inspector.
 
 > If you think that the switch button blocks your user interface, you can long press the switch button, wait for the switch button to enter the draggable state, and then adjust the display position of the switch button by dragging it.
 
 <img width="500" src="./public/toggle-button-demo.png" alt="toggle button demo"/>
 
-Clicking (shortcut key: ⌨️ <kbd>option ⌥</kbd> + <kbd>command ⌘</kbd> + <kbd>O</kbd>) will enable the inspector. We move the mouse to the point where we need to inspect Source code information can be seen on the element.
+Enable the inspector by clicking (shortcut: ⌨️ <kbd>option ⌥</kbd> + <kbd>command ⌘</kbd> + <kbd>O</kbd>) the toggle button in the upper right corner of your browser, then, We can see the source code location information by moving the mouse over the element that needs to be inspected.
 
 <img width="500" src="./public/inspect-element-demo.png" alt="inspect element demo"/>
 
-At this time, click element to automatically open the location of the source code in the editor.
+At this point, click on the element to automatically open the source code file in the code editor and locate the line and column.
 
 <img width="500" src="./public/open-editor-demo.png" alt="open editor demo"/>
 
-At this time, you can also choose to long press (shortcut key: ⌨️<kbd>command ⌘</kbd>+🖱click) element to view the complete component tree information.
+At this time, you can also choose to long press (shortcut key: ⌨️ <kbd>command ⌘</kbd> + 🖱 click) element to view the complete component tree.
 
 <img width="500" src="./public/open-tree-demo.png" alt="open editor demo"/>
 
@@ -110,7 +110,7 @@ Then click on the leaf node, and the location of the leaf node will automaticall
 
 ### Exit inspector
 
-Click again (shortcut key 1: ⌨️ <kbd>Options ⌥</kbd> + <kbd>Command ⌘</kbd> + <kbd>O</kbd>, shortcut key 2: ⌨️ <kbd>esc</kbd>, shortcut key 3: 🖱right click) button in the upper right corner of the browser will exit the inspector.
+Click again (shortcut key 1: ⌨️ <kbd>option ⌥</kbd> + <kbd>command ⌘</kbd> + <kbd>O</kbd>, shortcut key 2: ⌨️ <kbd>esc</kbd>, shortcut key 3: 🖱 right-click) the switch button in the upper right corner of the browser to exit the inspector.
 
 <img width="500" src="./public/toggle-button-demo2.png" alt="toggle button demo"/>
 
@@ -122,13 +122,13 @@ Click again (shortcut key 1: ⌨️ <kbd>Options ⌥</kbd> + <kbd>Command ⌘</k
 
 > Requires React version 15+.
 
-`open-editor` needs to be used with [`@babel/plugin-transform-react-jsx-source`](https://babeljs.io/docs/babel-plugin-transform-react-jsx-source), which It is a plug-in that obtains source code line and column information. Normally you don't need to pay attention to this thing because it is mainly built into the scaffolding tools. If you have issues with `open-editor` not being able to open source code, this would be a way to troubleshoot the issue.
+`open-editor` needs to be used with [`@babel/plugin-transform-react-jsx-source`](https://babeljs.io/docs/babel-plugin-transform-react-jsx-source), which is a plug-in for getting source code line and column information. Usually you don't have to pay attention to this thing because it is mainly built into the scaffolding tool. If you encounter the problem that `open-editor` cannot open the code editor, this will It will be a way to troubleshoot the problem.
 
 ### Vue
 
 > Requires Vue version 2+.
 
-`open-editor` needs to be used with [`unplugin-vue-source`](https://github.com/zjxxxxxxxxx/unplugin-vue-source), which is a plugin for getting source code line and column information , if this plug-in is missing, the source code file will only be opened in the editor, and there will be no way to accurately locate the rows and columns of the source code.
+`open-editor` needs to be used with [`unplugin-vue-source`](https://github.com/zjxxxxxxxxx/unplugin-vue-source), which is a plugin for getting source code line and column information , if this plug-in is missing, the source code file will only be opened in the code editor, but line and column cannot be located.
 
 ## Playgrounds
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,31 +86,31 @@ export default defineConfig({
 npm run dev
 ```
 
-然后在浏览器中打开项目的本地服务器地址，此时可以看见浏览器的右上角出现了一个切换按钮，这个切换按钮可以用于切换元素检查器的启用状态。
+此时在浏览器中打开项目的本地服务器地址，您会看见浏览器的右上角出现了一个切换按钮，这个切换按钮可以用于切换检查器的启用状态。
 
 > 如果您认为切换按钮遮挡住了您的用户界面，您可以长按切换按钮，等待切换按钮进入可拖拽状态后，以拖拽的方式调整切换按钮的显示位置
 
 <img width="500" src="./public/toggle-button-demo.png" alt="toggle button demo"/>
 
-点击（快捷键：⌨️ <kbd>option ⌥</kbd> + <kbd>command ⌘</kbd> + <kbd>O</kbd>）这个按钮就会启用检查器，我们把移动鼠标到需要检查的元素上就可以看见源代码信息。
+点击（快捷键：⌨️ <kbd>option ⌥</kbd> + <kbd>command ⌘</kbd> + <kbd>O</kbd>）浏览器右上角的切换按钮即可启用检查器，然后，我们移动鼠标到需要检查的元素上即可看见源代码位置信息。
 
 <img width="500" src="./public/inspect-element-demo.png" alt="inspect element demo"/>
 
-此时点击元素就可以自动在编辑器中打开源代码所在的位置。
+此时点击元素即可自动在代码编辑器中打开源代码文件，并定位到行和列。
 
 <img width="500" src="./public/open-editor-demo.png" alt="open editor demo"/>
 
-此时也可以选择长按（快捷键：⌨️ <kbd>command ⌘</kbd> + 🖱 click）元素查看完整组件树信息。
+此时也可以选择长按（快捷键：⌨️ <kbd>command ⌘</kbd> + 🖱 click）元素查看完整组件树。
 
 <img width="500" src="./public/open-tree-demo.png" alt="open editor demo"/>
 
-然后点击叶子节点就可以自动在编辑器中打开叶子节点所在的位置。
+然后点击树节点即可自动在代码编辑器中打开源代码文件，并定位到行和列。
 
 <img width="500" src="./public/open-editor-demo.png" alt="open editor demo"/>
 
 ### 退出检查器
 
-再次点击（快捷键1：⌨️ <kbd>option ⌥</kbd> + <kbd>command ⌘</kbd> + <kbd>O</kbd>，快捷键2：⌨️ <kbd>esc</kbd>，快捷键3：🖱 right-click）浏览器右上角的按钮就会退出检查器。
+再次点击（快捷键1：⌨️ <kbd>option ⌥</kbd> + <kbd>command ⌘</kbd> + <kbd>O</kbd>，快捷键2：⌨️ <kbd>esc</kbd>，快捷键3：🖱 right-click）浏览器右上角的切换按钮即可退出检查器。
 
 <img width="500" src="./public/toggle-button-demo2.png" alt="toggle button demo"/>
 
@@ -120,13 +120,13 @@ npm run dev
 
 > 需要 React 版本 15+。
 
-`open-editor`需要与[`@babel/plugin-transform-react-jsx-source`](https://babeljs.io/docs/babel-plugin-transform-react-jsx-source)一起使用，它是一个用于获取源代码行和列信息的插件，通常你不必关注这件事情，因为它主要内置在脚手架工具中，如果您遇到`open-editor`无法打开源代码的问题，这将会是一个排查问题的方式。
+`open-editor`需要与[`@babel/plugin-transform-react-jsx-source`](https://babeljs.io/docs/babel-plugin-transform-react-jsx-source)一起使用，它是一个用于获取源代码行和列信息的插件，通常你不必关注这件事情，因为它主要内置在脚手架工具中，如果您遇到`open-editor`无法打开代码编辑器的问题，这将会是一个排查问题的方式。
 
 ### Vue
 
 > 需要 Vue 版本 2+。
 
-`open-editor`需要与[`unplugin-vue-source`](https://github.com/zjxxxxxxxxx/unplugin-vue-source)一起使用，它是一个用于获取源代码行和列信息的插件，如果缺少这个插件，将只会在编辑器中打开源代码文件，而没有办法精准定位源代码的行和列。
+`open-editor`需要与[`unplugin-vue-source`](https://github.com/zjxxxxxxxxx/unplugin-vue-source)一起使用，它是一个用于获取源代码行和列信息的插件，如果缺少这个插件，将只会在代码编辑器中打开源代码文件，但无法定位到行和列。
 
 ## 演练场
 

--- a/packages/client/src/elements/defineInspectElement.ts
+++ b/packages/client/src/elements/defineInspectElement.ts
@@ -111,9 +111,6 @@ export function defineInspectElement() {
     connectedCallback() {
       on('keydown', this.onKeydown, capOpts);
       on('pointermove', this.savePointE, capOpts);
-      on('exit', this.cleanupHandlers, {
-        target: this.tree,
-      });
       onOpenEditorError(this.showErrorOverlay);
 
       if (this.toggle) {
@@ -126,9 +123,6 @@ export function defineInspectElement() {
     disconnectedCallback() {
       off('keydown', this.onKeydown, capOpts);
       off('pointermove', this.savePointE, capOpts);
-      off('exit', this.cleanupHandlers, {
-        target: this.tree,
-      });
       offOpenEditorError(this.showErrorOverlay);
 
       if (this.toggle) {
@@ -185,11 +179,10 @@ export function defineInspectElement() {
     private cleanupListenersOnWindow!: () => void;
 
     private cleanupHandlers = () => {
-      if (this.active) {
+      if (this.active && !this.tree.show) {
         this.active = false;
         overrideStyle.unmount();
         this.overlay.close();
-        this.tree.close();
         this.cleanupListenersOnWindow();
       }
     };

--- a/packages/client/src/elements/defineTreeElement.ts
+++ b/packages/client/src/elements/defineTreeElement.ts
@@ -18,6 +18,7 @@ import {
 } from '../resolve';
 
 export interface HTMLTreeElement extends HTMLElement {
+  show: boolean;
   open(el: HTMLElement): void;
   close(): void;
 }
@@ -135,6 +136,8 @@ const CSS = postcss`
 
 export function defineTreeElement() {
   class TreeElement extends HTMLElement implements HTMLTreeElement {
+    show = false;
+
     private root!: HTMLElement;
     private overlay!: HTMLElement;
     private popup!: HTMLElement;
@@ -208,6 +211,7 @@ export function defineTreeElement() {
     }
 
     open = (el: HTMLElement) => {
+      this.show = true;
       applyStyle(this.root, {
         display: 'block',
       });
@@ -215,6 +219,7 @@ export function defineTreeElement() {
     };
 
     close = () => {
+      this.show = false;
       applyStyle(this.root, {
         display: 'none',
       });
@@ -241,7 +246,6 @@ export function defineTreeElement() {
       const source = <ElementSourceMeta>(<unknown>el.dataset);
       if (this.checkHoldElement(e) && isStr(source.file)) {
         openEditor(source, (e) => this.dispatchEvent(e));
-        this.dispatchEvent(new CustomEvent('exit'));
       }
     };
 

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -1,5 +1,10 @@
 export interface Options {
   /**
+   * source rootDir path
+   */
+  rootDir: string;
+
+  /**
    * render the toggle into the browser
    *
    * @default true
@@ -14,16 +19,18 @@ export interface Options {
   colorMode?: 'auto' | 'light' | 'dark';
 
   /**
+   * exit the check after opening the editor or component tree
+   *
+   * @default true
+   */
+  once?: boolean;
+
+  /**
    * internal server port
    *
    * relative address is used when this parameter is empty
    */
   port?: string;
-
-  /**
-   * source rootDir path
-   */
-  rootDir: string;
 }
 
 let opts: Options;
@@ -35,6 +42,7 @@ export function setOptions(
     ...userOpts,
     displayToggle: userOpts.displayToggle ?? true,
     colorMode: userOpts.colorMode ?? 'auto',
+    once: userOpts.once ?? true,
   };
 }
 

--- a/packages/client/src/utils/setupListenersOnWindow.ts
+++ b/packages/client/src/utils/setupListenersOnWindow.ts
@@ -2,6 +2,7 @@ import { capOpts } from '../constants';
 import { applyAttrs } from './html';
 import { off, on } from './event';
 import { isValidElement } from './validElement';
+import { getOptions } from '../options';
 
 export interface SetupHandlersOptions {
   onChangeElement(el?: HTMLElement): void;
@@ -15,6 +16,8 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
   const onOpenEditor = wrapCleanHoldElement(opts.onOpenEditor);
   const onOpenTree = wrapCleanHoldElement(opts.onOpenTree);
   const onExitInspect = wrapCleanHoldElement(opts.onExitInspect);
+
+  const { once } = getOptions();
 
   function registerEventListeners() {
     on('click', onClick, {
@@ -96,8 +99,8 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
         onOpenTree(el);
         onChangeElement();
       } else {
+        if (once) onExitInspect();
         onOpenEditor(el);
-        onExitInspect();
       }
     }
   }
@@ -143,6 +146,7 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
 
     const el = <HTMLElement>e.target;
     if (isValidElement(el)) {
+      if (once) onExitInspect();
       onChangeElement();
       onOpenTree(el);
     }

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -27,6 +27,13 @@ export interface Options {
   colorMode?: 'auto' | 'light' | 'dark';
 
   /**
+   * exit the check after opening the editor or component tree
+   *
+   * @default true
+   */
+  once?: boolean;
+
+  /**
    * custom openEditor handler
    */
   onOpenEditor?(file: string): void;
@@ -44,6 +51,7 @@ export default function openEditorPlugin(
     rootDir = process.cwd(),
     displayToggle,
     colorMode,
+    once,
     onOpenEditor,
   } = options;
 
@@ -78,6 +86,7 @@ export default function openEditorPlugin(
         rootDir,
         displayToggle,
         colorMode,
+        once,
       });
     },
     transform(code, id) {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -27,6 +27,13 @@ export interface Options {
   colorMode?: 'auto' | 'light' | 'dark';
 
   /**
+   * exit the check after opening the editor or component tree
+   *
+   * @default true
+   */
+  once?: boolean;
+
+  /**
    * custom openEditor handler
    */
   onOpenEditor?(file: string): void;
@@ -44,6 +51,7 @@ export default function openEditorPlugin(
     rootDir = process.cwd(),
     displayToggle,
     colorMode,
+    once,
     onOpenEditor,
   } = options;
 
@@ -54,6 +62,7 @@ export default function openEditorPlugin(
     rootDir,
     displayToggle,
     colorMode,
+    once,
   });
 
   return {

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -26,6 +26,13 @@ export interface Options {
   colorMode?: 'auto' | 'light' | 'dark';
 
   /**
+   * exit the check after opening the editor or component tree
+   *
+   * @default true
+   */
+  once?: boolean;
+
+  /**
    * custom openEditor handler
    */
   onOpenEditor?(file: string): void;


### PR DESCRIPTION
Allows you to decide whether to automatically exit the check after opening the code editor or component tree by setting the `once` option.