### PR TITLE
fix: `once` not taking effect on close tree

### DIFF
--- a/.changeset/rich-rings-tie.md
+++ b/.changeset/rich-rings-tie.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Fixed `once` not taking effect on close tree

--- a/packages/client/src/elements/defineTreeElement.ts
+++ b/packages/client/src/elements/defineTreeElement.ts
@@ -16,6 +16,7 @@ import {
   type ElementSourceMeta,
   resolveSource,
 } from '../resolve';
+import { getOptions } from '../options';
 
 export interface HTMLTreeElement extends HTMLElement {
   show: boolean;
@@ -245,6 +246,8 @@ export function defineTreeElement() {
       const el = <HTMLElement>e.target!;
       const source = <ElementSourceMeta>(<unknown>el.dataset);
       if (this.checkHoldElement(e) && isStr(source.file)) {
+        const { once } = getOptions();
+        if (once) this.close();
         openEditor(source, (e) => this.dispatchEvent(e));
       }
     };


### PR DESCRIPTION
It is expected that when `once` is set to true, the tree popup will automatically close when the tree node is clicked.

The actual situation is that the tree popup does not close automatically.