### PR TITLE
fix: jsx syntax in plain js  @zjxxxxxxxxx

### DIFF
--- a/.changeset/four-bats-complain.md
+++ b/.changeset/four-bats-complain.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Fixed jsx syntax in plain js

--- a/.changeset/honest-paws-wash.md
+++ b/.changeset/honest-paws-wash.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/server': patch
+---
+
+Requests without referrer are prohibited from opening the editor

--- a/.changeset/weak-masks-flow.md
+++ b/.changeset/weak-masks-flow.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Hide overlay when `pointercancel` fires

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ At this time, you can also choose to long press (shortcut key: ⌨️ <kbd>comma
 
 <img width="500" src="./public/open-tree-demo.png" alt="open editor demo"/>
 
-Then click on the leaf node, and the location of the leaf node will automatically open in the editor.
+Then click on the tree node to automatically open the source code file in the code editor and locate the line and column.
 
 <img width="500" src="./public/open-editor-demo.png" alt="open editor demo"/>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,7 +126,7 @@ npm run dev
 
 > 需要 Vue 版本 2+。
 
-`open-editor`需要与[`unplugin-vue-source`](https://github.com/zjxxxxxxxxx/unplugin-vue-source)一起使用，它是一个用于获取源代码行和列信息的插件，如果缺少这个插件，将只会在代码编辑器中打开源代码文件，但无法定位到行和列。
+`open-editor`需要与[`unplugin-vue-source`](https://github.com/zjxxxxxxxxx/unplugin-vue-source)一起使用，它是一个用于获取源代码行和列信息的插件，如果缺少这个插件，将只会在代码编辑器中打开源代码文件，而无法定位到行和列。
 
 ## 演练场
 

--- a/packages/client/src/elements/defineInspectElement.ts
+++ b/packages/client/src/elements/defineInspectElement.ts
@@ -99,11 +99,10 @@ export function defineInspectElement() {
           jsx<HTMLTreeElement>(InternalElements.HTML_TREE_ELEMENT, {
             ref: (el) => (this.tree = el),
           }),
-          opts.displayToggle
-            ? jsx<HTMLToggleElement>(InternalElements.HTML_TOGGLE_ELEMENT, {
-                ref: (el) => (this.toggle = el),
-              })
-            : null,
+          opts.displayToggle &&
+            jsx<HTMLToggleElement>(InternalElements.HTML_TOGGLE_ELEMENT, {
+              ref: (el) => (this.toggle = el),
+            }),
         ],
       });
     }

--- a/packages/client/src/elements/defineTreeElement.ts
+++ b/packages/client/src/elements/defineTreeElement.ts
@@ -330,17 +330,23 @@ export function defineTreeElement() {
         title: withFile ? 'Click to open in your editor' : null,
         ...dataset,
       },
-      jsx('span', {
-        className: 'name',
-        __text: withFile ? `<${name}>` : `<${name}/>`,
-        ...dataset,
-      }),
+      jsx(
+        'span',
+        {
+          className: 'name',
+          ...dataset,
+        },
+        withFile ? `<${name}>` : `<${name}/>`,
+      ),
       withFile
-        ? jsx('span', {
-            className: 'file',
-            __text: `${file}:${line}:${column}`,
-            ...dataset,
-          })
+        ? jsx(
+            'span',
+            {
+              className: 'file',
+              ...dataset,
+            },
+            `${file}:${line}:${column}`,
+          )
         : null,
     );
   }

--- a/packages/client/src/resolve/createVueResolver.ts
+++ b/packages/client/src/resolve/createVueResolver.ts
@@ -160,7 +160,7 @@ function getIsSourceResult<T = any>(
   return false;
 }
 
-const nameRE = /([^/.]+)\.(vue|jsx|tsx)$/;
+const nameRE = /([^/.]+)\.(vue|jsx|tsx|js|ts|mjs|cjs)$/;
 function getNameByFile(file = '') {
   return file.match(nameRE)?.[1];
 }

--- a/packages/client/src/utils/html/host.ts
+++ b/packages/client/src/utils/html/host.ts
@@ -1,10 +1,10 @@
 import { isArr } from '@open-editor/shared';
 import { append } from './dom';
-import { Children, jsx } from './jsx';
+import { JSXNode, jsx } from './jsx';
 
 export interface Options {
   css: string | string[];
-  html: Children[0] | Children;
+  html: JSXNode | JSXNode[];
 }
 
 export function host(root: HTMLElement, opts: Options) {

--- a/packages/client/src/utils/html/jsx.ts
+++ b/packages/client/src/utils/html/jsx.ts
@@ -2,30 +2,34 @@ import { isStr } from '@open-editor/shared';
 import { append, applyAttrs } from './dom';
 import { addClass, applyStyle } from './style';
 
-export interface Props<T = HTMLElement> extends Record<string, any> {
+export interface JSXProps<T = HTMLElement> extends Record<string, any> {
   ref?(el: T): void;
   className?: string;
   style?: Partial<CSSStyleDeclaration>;
   __html?: string;
-  __text?: string;
 }
 
-export type Children = (HTMLElement | string | null)[];
+export type JSXNode = HTMLElement | string | false | null | undefined;
 
 export function jsx<K extends keyof HTMLElementTagNameMap>(
   type: K,
-  props?: Props<HTMLElementTagNameMap[K]>,
-  ...children: Children
+  props?: JSXProps<HTMLElementTagNameMap[K]>,
+  ...children: JSXNode[]
 ): HTMLElementTagNameMap[K];
 export function jsx<T extends HTMLElement>(
   type: string,
-  props?: Props<T>,
-  ...children: Children
+  props?: JSXProps<T>,
+  ...children: JSXNode[]
 ): T;
-export function jsx(type: string, props: Props = {}, ...children: Children) {
+export function jsx(
+  type: string,
+  props: JSXProps = {},
+  ...children: JSXNode[]
+) {
+  const { ref, className, style, __html, ...attrs } = props;
+
   const el = document.createElement(type);
 
-  const { ref, className, style, __html, __text, ...attrs } = props;
   if (className) {
     addClass(el, className);
   }
@@ -34,13 +38,11 @@ export function jsx(type: string, props: Props = {}, ...children: Children) {
   }
   if (__html) {
     el.innerHTML = __html;
-  } else if (__text) {
-    el.innerText = __text;
   }
   applyAttrs(el, attrs);
 
   for (const child of children) {
-    if (child !== null) {
+    if (child) {
       append(el, isStr(child) ? document.createTextNode(child) : child);
     }
   }

--- a/packages/client/src/utils/html/style.ts
+++ b/packages/client/src/utils/html/style.ts
@@ -1,6 +1,7 @@
-import { isNaN } from '@open-editor/shared';
 import { append } from './dom';
 import { jsx } from './jsx';
+
+type PartialWithNull<T> = { [P in keyof T]?: T[P] | undefined | null };
 
 export const CSS_util = {
   px(value: string | number) {
@@ -11,7 +12,6 @@ export const CSS_util = {
   },
 };
 
-type PartialWithNull<T> = { [P in keyof T]?: T[P] | undefined | null };
 export function applyStyle(
   el: HTMLElement,
   ...styles: PartialWithNull<CSSStyleDeclaration>[]
@@ -29,11 +29,9 @@ export function computedStyle(el: Element) {
     // @ts-ignore
     toNumber: ToNumber = true,
   ) {
-    const value = style.getPropertyValue(property);
-    if (toNumber) {
-      const valueNumber = CSS_util.pv(value);
-      return <ReturnValue>(isNaN(valueNumber) ? 0 : valueNumber);
-    }
+    let value = style.getPropertyValue(property);
+    // @ts-ignore
+    if (toNumber) value = CSS_util.pv(value) || 0;
     return <ReturnValue>value;
   };
 }

--- a/packages/client/src/utils/setupListenersOnWindow.ts
+++ b/packages/client/src/utils/setupListenersOnWindow.ts
@@ -20,10 +20,7 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
   const { once } = getOptions();
 
   function registerEventListeners() {
-    on('click', onClick, {
-      ...capOpts,
-      target: document,
-    });
+    on('click', onClick, capOpts);
 
     on('mousedown', onSilence, capOpts);
     on('mouseenter', onSilence, capOpts);
@@ -33,12 +30,12 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
     on('mouseover', onSilence, capOpts);
     on('mouseup', onSilence, capOpts);
 
-    on('pointercancel', onSilence, capOpts);
+    on('pointercancel', onPointerCancel, capOpts);
     on('pointerdown', onPointerDown, capOpts);
     on('pointerenter', onSilence, capOpts);
     on('pointerleave', onSilence, capOpts);
     on('pointermove', onSilence, capOpts);
-    on('pointerout', onSilence, capOpts);
+    on('pointerout', onPointerCancel, capOpts);
     on('pointerover', onPointerOver, capOpts);
     on('pointerup', onSilence, capOpts);
 
@@ -47,16 +44,14 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
     on('touchcancel', onSilence, capOpts);
     on('touchmove', onTouchMove, capOpts);
 
-    on('keydown', onKeyDown, capOpts);
-    on('contextmenu', onContextMenu, capOpts);
     on('longpress', onLongPress, capOpts);
+
+    on('keydown', onQuickExit, capOpts);
+    on('contextmenu', onQuickExit, capOpts);
   }
 
   function removeEventListeners() {
-    off('click', onClick, {
-      ...capOpts,
-      target: document,
-    });
+    off('click', onClick, capOpts);
 
     off('mousedown', onSilence, capOpts);
     off('mouseenter', onSilence, capOpts);
@@ -66,12 +61,12 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
     off('mouseover', onSilence, capOpts);
     off('mouseup', onSilence, capOpts);
 
-    off('pointercancel', onSilence, capOpts);
+    off('pointercancel', onPointerCancel, capOpts);
     off('pointerdown', onPointerDown, capOpts);
     off('pointerenter', onSilence, capOpts);
     off('pointerleave', onSilence, capOpts);
     off('pointermove', onSilence, capOpts);
-    off('pointerout', onSilence, capOpts);
+    off('pointerout', onPointerCancel, capOpts);
     off('pointerover', onPointerOver, capOpts);
     off('pointerup', onSilence, capOpts);
 
@@ -80,9 +75,10 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
     off('touchcancel', onSilence, capOpts);
     off('touchmove', onTouchMove, capOpts);
 
-    off('keydown', onKeyDown, capOpts);
-    off('contextmenu', onContextMenu, capOpts);
     off('longpress', onLongPress, capOpts);
+
+    off('keydown', onQuickExit, capOpts);
+    off('contextmenu', onQuickExit, capOpts);
   }
 
   function onPointerDown(e: PointerEvent) {
@@ -113,6 +109,11 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
     onChangeElement(changedEl);
   }
 
+  function onPointerCancel(e: PointerEvent) {
+    onSilence(e);
+    onChangeElement();
+  }
+
   let lastTouchEl: HTMLElement | undefined;
   function onTouchMove(e: TouchEvent) {
     onSilence(e);
@@ -125,18 +126,14 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
     }
   }
 
-  // esc exit.
-  function onKeyDown(e: KeyboardEvent) {
-    onSilence(e, true);
-    if (e.key === 'Escape') {
-      onExitInspect();
-    }
-  }
-
-  // right-click exit.
-  function onContextMenu(e: PointerEvent) {
-    onSilence(e, true);
-    if (e.pointerType === 'mouse') {
+  function onQuickExit(e: PointerEvent) {
+    if (
+      // esc exit.
+      (<any>e).key === 'Escape' ||
+      // right-click exit.
+      e.pointerType === 'mouse'
+    ) {
+      onSilence(e, true);
       onExitInspect();
     }
   }

--- a/packages/client/src/utils/validElement.ts
+++ b/packages/client/src/utils/validElement.ts
@@ -7,9 +7,8 @@ function isInternalElement(el: HTMLElement) {
   return internalElementRE.test(el.localName);
 }
 
-const filterElementRE = /^(html|iframe)$/;
 function isFilterElement(el: HTMLElement) {
-  return filterElementRE.test(el.localName);
+  return el.localName === 'iframe';
 }
 
 export function isValidElement(el?: HTMLElement | null) {

--- a/packages/server/src/openEditorMiddleware.ts
+++ b/packages/server/src/openEditorMiddleware.ts
@@ -40,11 +40,14 @@ export function openEditorMiddleware(
       res.end(sendMessage('Invalid'));
       return;
     }
-    res.setHeader('Content-Type', 'text/javascript');
+
+    res.setHeader('Content-Type', 'application/javascript;charset=UTF-8');
     res.end(readFileSync(filename, 'utf-8'));
 
-    const { line = 1, column = 1 } = query;
-    onOpenEditor(`${filename}:${line}:${column}`);
+    if (req.headers.referer) {
+      const { line = 1, column = 1 } = query;
+      onOpenEditor(`${filename}:${line}:${column}`);
+    }
   };
 }
 


### PR DESCRIPTION
[client] [fix: jsx syntax in plain js](https://github.com/zjxxxxxxxxx/open-editor/commit/178d7d35ce76b774802ab54a8b1451133ab3c905)
[server] [feat: Requests without referrer are prohibited from opening the editor](https://github.com/zjxxxxxxxxx/open-editor/commit/644a9fca29dbd8af1fccd27a0b81e7b71d485d69)
[client] [feat: Hide overlay when pointercancel fires](https://github.com/zjxxxxxxxxx/open-editor/commit/1ee3f287da41fa09104e7eb4c5a7e2b93c633b94)