### PR TITLE
fix: Make screen unscrollable

### DIFF
--- a/.changeset/fresh-suns-grab.md
+++ b/.changeset/fresh-suns-grab.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Make screen unscrollable

--- a/packages/client/src/elements/defineInspectElement.ts
+++ b/packages/client/src/elements/defineInspectElement.ts
@@ -155,8 +155,13 @@ export function defineInspectElement() {
     private setupHandlers() {
       if (!this.active) {
         this.active = true;
-        overrideStyle.mount();
         this.overlay.open();
+        this.cleanupListenersOnWindow = setupListenersOnWindow({
+          onChangeElement: this.overlay.update,
+          onOpenTree: this.tree.open,
+          onOpenEditor: this.openEditor,
+          onExitInspect: this.cleanupHandlers,
+        });
 
         if (this.pointE) {
           const { x, y } = this.pointE;
@@ -166,12 +171,7 @@ export function defineInspectElement() {
           }
         }
 
-        this.cleanupListenersOnWindow = setupListenersOnWindow({
-          onChangeElement: this.overlay.update,
-          onOpenTree: this.tree.open,
-          onOpenEditor: this.openEditor,
-          onExitInspect: this.cleanupHandlers,
-        });
+        overrideStyle.mount();
       }
     }
 
@@ -180,9 +180,10 @@ export function defineInspectElement() {
     private cleanupHandlers = () => {
       if (this.active && !this.tree.show) {
         this.active = false;
-        overrideStyle.unmount();
         this.overlay.close();
         this.cleanupListenersOnWindow();
+
+        overrideStyle.unmount();
       }
     };
 

--- a/packages/client/src/elements/defineToggleElement.ts
+++ b/packages/client/src/elements/defineToggleElement.ts
@@ -5,7 +5,7 @@ import {
   applyStyle,
   host,
   addClass,
-  reomveClass,
+  removeClass,
 } from '../utils/html';
 import { off, on } from '../utils/event';
 import { create_RAF } from '../utils/createRAF';
@@ -88,7 +88,7 @@ export function defineToggleElement() {
       if (newValue === 'true') {
         addClass(this.button, 'active');
       } else {
-        reomveClass(this.button, 'active');
+        removeClass(this.button, 'active');
       }
     }
 

--- a/packages/client/src/elements/defineTreeElement.ts
+++ b/packages/client/src/elements/defineTreeElement.ts
@@ -5,7 +5,9 @@ import {
   applyStyle,
   host,
   addClass,
-  reomveClass,
+  removeClass,
+  getHtml,
+  globalStyle,
 } from '../utils/html';
 import { off, on } from '../utils/event';
 import { openEditor } from '../utils/openEditor';
@@ -182,6 +184,10 @@ export function defineTreeElement() {
     }
 
     connectedCallback() {
+      globalStyle(postcss`.oe-screen-lock {
+        overflow: hidden;
+      }`).mount();
+
       on('pointerdown', this.setHoldElement, {
         target: this.root,
       });
@@ -216,14 +222,16 @@ export function defineTreeElement() {
       applyStyle(this.root, {
         display: 'block',
       });
+      addClass(getHtml(), 'oe-screen-lock');
       this.renderBodyContent(resolveSource(el, true));
     };
 
     close = () => {
       this.show = false;
       applyStyle(this.root, {
-        display: 'none',
+        display: null,
       });
+      removeClass(getHtml(), 'oe-screen-lock');
       this.renderBodyContent();
     };
 
@@ -261,7 +269,7 @@ export function defineTreeElement() {
       const hasTree = source.tree.length > 0;
       const treeNodes = hasTree ? buildTree(source.tree) : ['>> not found 😭.'];
 
-      if (hasTree) reomveClass(this.popup, 'error');
+      if (hasTree) removeClass(this.popup, 'error');
       else addClass(this.popup, 'error');
 
       append(

--- a/packages/client/src/resolve/createVueResolver.ts
+++ b/packages/client/src/resolve/createVueResolver.ts
@@ -160,7 +160,7 @@ function getIsSourceResult<T = any>(
   return false;
 }
 
-const nameRE = /([^/.]+)\.(vue|jsx|tsx|js|ts|mjs|cjs)$/;
+const nameRE = /([^/.]+)\.[^.]+$/;
 function getNameByFile(file = '') {
   return file.match(nameRE)?.[1];
 }

--- a/packages/client/src/utils/html/style.ts
+++ b/packages/client/src/utils/html/style.ts
@@ -46,7 +46,7 @@ export function globalStyle(css: string) {
     mount() {
       if (!isMounted) {
         isMounted = true;
-        append(document.body, style);
+        append(document.head, style);
       }
     },
     unmount() {
@@ -62,6 +62,6 @@ export function addClass(el: HTMLElement, className: string) {
   el.classList.add(...className.split(' '));
 }
 
-export function reomveClass(el: HTMLElement, className: string) {
+export function removeClass(el: HTMLElement, className: string) {
   el.classList.remove(...className.split(' '));
 }

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -52,6 +52,12 @@ interface Options {
    */
   colorMode?: 'auto' | 'light' | 'dark';
   /**
+   * exit the check after opening the editor or component tree
+   *
+   * @default true
+   */
+  once?: boolean;
+  /**
    * custom openEditor handler
    */
   onOpenEditor?(file: string): void;

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -52,6 +52,12 @@ interface Options {
    */
   colorMode?: 'auto' | 'light' | 'dark';
   /**
+   * exit the check after opening the editor or component tree
+   *
+   * @default true
+   */
+  once?: boolean;
+  /**
    * custom openEditor handler
    */
   onOpenEditor?(file: string): void;

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -52,6 +52,12 @@ interface Options {
    */
   colorMode?: 'auto' | 'light' | 'dark';
   /**
+   * exit the check after opening the editor or component tree
+   *
+   * @default true
+   */
+  once?: boolean;
+  /**
    * custom openEditor handler
    */
   onOpenEditor?(file: string): void;


### PR DESCRIPTION
1. Lock the screen while the component tree is open to avoid unnecessary scrolling.
2. Use a looser approach to matching component names because we cannot accurately predict all possible cases.