### PR TITLE
feat: Press `esc` to exit the component tree

### DIFF
--- a/.changeset/thirty-seahorses-fetch.md
+++ b/.changeset/thirty-seahorses-fetch.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Press `esc` to exit the component tree


### PR DESCRIPTION
A more convenient way to exit the component tree is to press the `esc` key to exit.