### PR TITLE
fix: Click event accidentally triggered by pressing Enter key

### DIFF
--- a/packages/client/src/elements/defineToggleElement.ts
+++ b/packages/client/src/elements/defineToggleElement.ts
@@ -201,6 +201,9 @@ export function defineToggleElement() {
     });
 
     private dispatchToggle = () => {
+      // Let the button lose focus to prevent the click event from being accidentally triggered by pressing the Enter key or the Space bar.
+      this.button.blur();
+
       // Prevents the click event from being triggered by the end of the drag
       if (!this.dndPoint) {
         this.dispatchEvent(new CustomEvent('toggle'));

--- a/packages/client/src/utils/setupListenersOnWindow.ts
+++ b/packages/client/src/utils/setupListenersOnWindow.ts
@@ -91,11 +91,11 @@ export function setupListenersOnWindow(opts: SetupHandlersOptions) {
 
     const el = <HTMLElement>e.target;
     if (el === holdEl) {
+      if (once) onExitInspect();
       if (e.metaKey) {
         onOpenTree(el);
         onChangeElement();
       } else {
-        if (once) onExitInspect();
         onOpenEditor(el);
       }
     }


### PR DESCRIPTION
Let the button lose focus to prevent the click event from being accidentally triggered by pressing the Enter key or the Space bar.