### PR TITLE
feat: Convert component name to camel case

### DIFF
--- a/.changeset/curvy-birds-heal.md
+++ b/.changeset/curvy-birds-heal.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Convert component name to camel case

--- a/packages/client/src/elements/defineTreeElement.ts
+++ b/packages/client/src/elements/defineTreeElement.ts
@@ -112,7 +112,7 @@ const CSS = postcss`
 }
 .oe-tag {
   margin: 2px 0;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
   opacity: 0.6;
 }
@@ -324,13 +324,13 @@ export function defineTreeElement() {
     const { name, file, line = 1, column = 1 } = meta ?? {};
     const dataset = withFile ? toDataset(meta) : {};
     return jsx(
-      'span',
+      'p',
       {
         className: 'oe-tag',
         title: withFile ? 'Click to open in your editor' : null,
         ...dataset,
       },
-      withFile ? `<${name}>` : `<${name}/>`,
+      `<${name}>`,
       withFile
         ? jsx(
             'span',

--- a/packages/client/src/resolve/index.ts
+++ b/packages/client/src/resolve/index.ts
@@ -1,3 +1,4 @@
+import { upperCase } from '../utils/util';
 import { ensureFileName } from './util';
 import { resolveDebug } from './resolveDebug';
 import { resolveReact17Plus } from './resolves/react17+';
@@ -44,7 +45,7 @@ export function resolveSource(el: HTMLElement, deep?: boolean): SourceCode {
 
 export function normalizeMeta(meta: Partial<SourceCodeMeta>) {
   return {
-    name: meta.name || 'Anonymous',
+    name: meta.name ? upperCase(meta.name, true) : 'Anonymous',
     file: ensureFileName(meta.file!),
     line: meta.line || 1,
     column: meta.column || 1,

--- a/packages/client/src/utils/isValidElement.ts
+++ b/packages/client/src/utils/isValidElement.ts
@@ -8,7 +8,7 @@ function isInternalElement(el: HTMLElement) {
 const filters = [
   // The `html` check is triggered when the mouse leaves the browser,
   // and filtering is needed to ignore this unexpected check.
-  // 'html',
+  'html',
   // `iframe` should be left to the internal inspector.
   'iframe',
 ];

--- a/packages/client/src/utils/util.ts
+++ b/packages/client/src/utils/util.ts
@@ -12,3 +12,12 @@ export function omit<T extends AnyObject, K extends keyof T>(
   }
   return newVal;
 }
+
+const upperFirstRE = /^[a-z]/;
+const upperCaseRE = /[.\-_ ]+([a-z])/g;
+export function upperCase(str: string, upperFirst?: boolean) {
+  if (upperFirst) {
+    str = str.replace(upperFirstRE, (char) => char.toUpperCase());
+  }
+  return str.replace(upperCaseRE, (_, char) => char.toUpperCase());
+}


### PR DESCRIPTION
All non-camel cased component names are converted to BumbleCase before displaying.