### PR TITLE
fix: Dynamic import of `client`

### DIFF
--- a/.changeset/eleven-plants-compare.md
+++ b/.changeset/eleven-plants-compare.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/shared': patch
+---
+
+Add option `dynamicImport`

--- a/.changeset/fluffy-suits-brake.md
+++ b/.changeset/fluffy-suits-brake.md
@@ -1,0 +1,6 @@
+---
+'@open-editor/webpack': patch
+'@open-editor/vite': patch
+---
+
+Dynamic import of `client`

--- a/.changeset/strong-dragons-shop.md
+++ b/.changeset/strong-dragons-shop.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Process all ancestor elements of the holding element

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,7 @@
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
-    "./client": "./dist/client.js"
+    "./client": "./dist/client.mjs"
   },
   "files": [
     "dist"

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,2 +1,3 @@
 // compile time generation
+'use client';
 throw Error('@open-editor/client: require a restart.');

--- a/packages/client/src/elements/HTMLInspectElement/index.tsx
+++ b/packages/client/src/elements/HTMLInspectElement/index.tsx
@@ -20,16 +20,24 @@ import { getOptions } from '../../options';
 import { resolveSource } from '../../resolve';
 import { HTMLCustomElement } from '../HTMLCustomElement';
 
-const overrideCSS = postcss`
+// mount global style
+globalStyle(postcss`
+.oe-screen-lock {
+  overflow: hidden;
+}
+.oe-loading * {
+  cursor: wait !important;
+}
+`).mount();
+
+const overrideStyle = globalStyle(postcss`
 * {
   cursor: default !important;
   user-select: none !important;
   touch-action: none !important;
   -webkit-touch-callout: none !important;
 }
-`;
-
-const overrideStyle = globalStyle(overrideCSS);
+`);
 
 export class HTMLInspectElementConstructor
   extends HTMLCustomElement<{
@@ -77,10 +85,6 @@ export class HTMLInspectElementConstructor
   }
 
   connectedCallback() {
-    globalStyle(
-      '.oe-screen-lock{overflow:hidden;}.oe-loading *{cursor:wait!important;}',
-    ).mount();
-
     on('keydown', this.onKeydown, capOpts);
     on('mousemove', this.savePointE, capOpts);
     onOpenEditorError(this.showErrorOverlay);

--- a/packages/client/src/elements/HTMLTreeElement/index.css
+++ b/packages/client/src/elements/HTMLTreeElement/index.css
@@ -39,7 +39,7 @@
   backdrop-filter: contrast(0.5);
 }
 .oe-body {
-  padding: 16px 24px;
+  padding: 20px 28px;
   overflow: hidden;
 }
 .oe-error,
@@ -64,7 +64,7 @@
   display: none;
 }
 .oe-title {
-  padding: 0 32px 16px 0;
+  padding: 0 16px 14px 0;
   font-size: 18px;
   font-weight: 500;
 }

--- a/packages/client/src/utils/getColorMode.ts
+++ b/packages/client/src/utils/getColorMode.ts
@@ -5,7 +5,7 @@ const LightColors = postcss`
   --text: #000000;
   --text-2: #333333;
   --fill: #f6f7f8;
-  --fill-opt: #f6f7f888;
+  --fill-opt: #f6f7f877;
   --fill-2: #c6c7c8;
   --cyan: #2dd9da;
   --red: #ff335c;
@@ -18,7 +18,7 @@ const DarkColors = postcss`
   --text: #ffffff;
   --text-2: #cccccc;
   --fill: #292a2d;
-  --fill-opt: #292a2daa;
+  --fill-opt: #292a2d88;
   --fill-2: #595a5d;
   --cyan: #4df9fa;
   --red: #ff335c;

--- a/packages/client/src/utils/holdElement.ts
+++ b/packages/client/src/utils/holdElement.ts
@@ -60,16 +60,14 @@ function resetAttrs(
   >,
 ) {
   const { disabled, href } = attrs;
-
-  // Prevent click events from being blocked
-  swapAttr(el, disabled.from, disabled.to);
+  const { as, bs } = findTags(el);
 
   // Prevents the default jump
   // `e.preventDefault()` has no effect on relative paths
-  const a = findATag(el);
-  if (a) {
-    swapAttr(a, href.from, href.to);
-  }
+  as.forEach((a) => swapAttr(a, href.from, href.to));
+
+  // Prevent click events from being blocked
+  bs.forEach((b) => swapAttr(b, disabled.from, disabled.to));
 }
 
 function swapAttr(el: HTMLElement, from: string, to: string) {
@@ -82,12 +80,21 @@ function swapAttr(el: HTMLElement, from: string, to: string) {
   }
 }
 
-function findATag(el: HTMLElement | null) {
+function findTags(el: HTMLElement | null) {
+  const as: HTMLElement[] = [];
+  const bs: HTMLElement[] = [];
+
   while (el) {
     if (el.tagName === 'A') {
-      return el;
+      as.push(el);
+    } else if (el.tagName === 'BUTTON') {
+      bs.push(el);
     }
     el = el.parentElement;
   }
-  return null;
+
+  return {
+    as,
+    bs,
+  };
 }

--- a/packages/client/src/utils/ui/style.tsx
+++ b/packages/client/src/utils/ui/style.tsx
@@ -37,20 +37,9 @@ export function computedStyle(el: HTMLElement) {
 
 export function globalStyle(css: string) {
   const style = <style type="text/css">{css}</style>;
-  let isMounted = false;
   return {
-    mount() {
-      if (!isMounted) {
-        isMounted = true;
-        append(document.head, style);
-      }
-    },
-    unmount() {
-      if (isMounted) {
-        isMounted = false;
-        style.remove();
-      }
-    },
+    mount: () => !style.isConnected && append(document.head, style),
+    unmount: () => style.isConnected && style.remove(),
   };
 }
 

--- a/packages/rollup/test/array-input.test.ts
+++ b/packages/rollup/test/array-input.test.ts
@@ -31,7 +31,7 @@ describe('string-input', async () => {
     expect((<OutputChunk>output[2]).moduleIds).toEqual([
       resolve(sharedRoot, 'dist/index.mjs'),
       resolve(clientRoot, 'dist/index.mjs'),
-      resolve(clientRoot, 'dist/client.js'),
+      resolve(clientRoot, 'dist/client.mjs'),
     ]);
   });
 });

--- a/packages/rollup/test/object-input.test.ts
+++ b/packages/rollup/test/object-input.test.ts
@@ -31,7 +31,7 @@ describe('string-input', async () => {
     expect((<OutputChunk>output[2]).moduleIds).toEqual([
       resolve(sharedRoot, 'dist/index.mjs'),
       resolve(clientRoot, 'dist/index.mjs'),
-      resolve(clientRoot, 'dist/client.js'),
+      resolve(clientRoot, 'dist/client.mjs'),
     ]);
   });
 });

--- a/packages/rollup/test/string-input.test.ts
+++ b/packages/rollup/test/string-input.test.ts
@@ -20,7 +20,7 @@ describe('string-input', async () => {
     expect(output[0].moduleIds).toEqual([
       resolve(sharedRoot, 'dist/index.mjs'),
       resolve(clientRoot, 'dist/index.mjs'),
-      resolve(clientRoot, 'dist/client.js'),
+      resolve(clientRoot, 'dist/client.mjs'),
       joinURLToPath(import.meta.url, 'app.js'),
     ]);
   });

--- a/packages/shared/src/createClient.ts
+++ b/packages/shared/src/createClient.ts
@@ -2,18 +2,30 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolvePath } from './resolve';
 
 const clientId = '@open-editor/client/client';
-const template = <const>`import { setupClient } from './index';
+const syncTemplate = <const>`
+'use client';
+import { setupClient } from './index';
 if (typeof window !== 'undefined') {
   setupClient(__OPTIONS__)
-}`;
+}
+`;
+const asyncTemplate = <const>` 
+'use client';
+if (typeof window !== 'undefined') {
+  import('./index').then(({ setupClient }) => {
+    setupClient(__OPTIONS__)
+  })
+}
+`;
 
 export function createClient(url: string) {
   const filename = resolvePath(clientId, url);
 
-  function generate(options: object) {
+  function generate(options: object, dynamicImport = false) {
     const oldCode = existsSync(filename)
       ? readFileSync(filename, 'utf-8')
       : undefined;
+    const template = dynamicImport ? asyncTemplate : syncTemplate;
     const newCode = template.replace('__OPTIONS__', JSON.stringify(options));
 
     if (newCode !== oldCode) {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -58,12 +58,15 @@ export default function openEditorPlugin(
   const VITE_CLIENT_PATH = '/vite/dist/client/client.mjs';
 
   const client = createClient(import.meta.url);
-  client.generate({
-    rootDir,
-    displayToggle,
-    colorMode,
-    once,
-  });
+  client.generate(
+    {
+      rootDir,
+      displayToggle,
+      colorMode,
+      once,
+    },
+    true,
+  );
 
   return {
     name: 'vite:open-editor',

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -87,10 +87,13 @@ export default class OpenEditorPlugin {
   ): Promise<ReturnType<Callback>> {
     const client = createClient(import.meta.url);
     getServerPort(this.options).then((port) => {
-      client.generate({
-        ...this.options,
-        port,
-      });
+      client.generate(
+        {
+          ...this.options,
+          port,
+        },
+        true,
+      );
     });
     return callback(client.filename);
   }


### PR DESCRIPTION
You need to dynamically import `client` in `webpack` and `vite`, because without using dynamic import, some code that is only valid on the client side will be executed in server-side rendering, which will generate errors.

