### PR TITLE
refactor: Use `jsx` syntax to bind events

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+packages/client/jsx

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "rimraf": "^5.0.1",
     "rollup": "^3.28.1",
     "rollup-plugin-dts": "^5.3.1",
-    "rollup-plugin-esbuild": "^5.0.0",
+    "rollup-plugin-esbuild": "^6.0.0",
     "simple-git-hooks": "^2.9.0",
     "turbo": "^1.10.12",
     "typescript": "^5.1.6",

--- a/packages/client/jsx/jsx-runtime.d.ts
+++ b/packages/client/jsx/jsx-runtime.d.ts
@@ -1,9 +1,36 @@
+declare type Letter = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[number];
+
+declare type EventKey<K extends string> = K extends `on${infer F}${infer _}`
+  ? F extends Letter
+    ? true
+    : false
+  : false;
+
+declare type EventType<K extends string> = K extends `on${infer F}`
+  ? Lowercase<F>
+  : never;
+
+declare type Event<K extends string> = HTMLElementEventMap[EventType<K>];
+
+declare type CustomNode =
+  | HTMLElement
+  | string
+  | number
+  | false
+  | null
+  | undefined;
+
 declare type CustomProperty<P> = {
   [K in keyof P]: K extends 'children'
-    ? (HTMLElement | string | number | false | null | undefined)[]
+    ? CustomNode[]
     : K extends 'ref'
     ? (el: HTMLElement) => void
+    : EventKey<K> extends true
+    ? (e: Event<K>) => void
     : P[K];
+} & {
+  onLongPress?(e: PointerEvent): void;
+  onQuickExit?(e: PointerEvent): void;
 };
 
 declare type CustomPropertyElements<ES> = {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,3 +1,2 @@
 // compile time generation
-'use client';
 throw Error('@open-editor/client: require a restart.');

--- a/packages/client/src/elements/HTMLInspectElement/index.tsx
+++ b/packages/client/src/elements/HTMLInspectElement/index.tsx
@@ -1,7 +1,7 @@
 import {
   applyAttrs,
   globalStyle,
-  append,
+  appendChild,
   addClass,
   removeClass,
   getHtml,
@@ -15,7 +15,7 @@ import {
   openEditor,
 } from '../../utils/openEditor';
 import { getColorMode } from '../../utils/getColorMode';
-import { InternalElements, capOpts } from '../../constants';
+import { InternalElements } from '../../constants';
 import { getOptions } from '../../options';
 import { resolveSource } from '../../resolve';
 import { HTMLCustomElement } from '../HTMLCustomElement';
@@ -39,16 +39,13 @@ const overrideStyle = globalStyle(postcss`
 }
 `);
 
-export class HTMLInspectElementConstructor
-  extends HTMLCustomElement<{
-    overlay: HTMLOverlayElement;
-    tree: HTMLTreeElement;
-    toggle?: HTMLToggleElement;
-    pointE: PointerEvent;
-    active: boolean;
-  }>
-  implements HTMLInspectElement
-{
+export class HTMLInspectElement extends HTMLCustomElement<{
+  overlay: HTMLOverlayElement;
+  tree: HTMLTreeElement;
+  toggle?: HTMLToggleElement;
+  pointE: PointerEvent;
+  active: boolean;
+}> {
   private get active() {
     return this.state.active;
   }
@@ -62,7 +59,7 @@ export class HTMLInspectElementConstructor
     }
   }
 
-  host() {
+  override host() {
     const opts = getOptions();
 
     return (
@@ -78,36 +75,24 @@ export class HTMLInspectElementConstructor
         {opts.displayToggle && (
           <InternalElements.HTML_TOGGLE_ELEMENT
             ref={(el) => (this.state.toggle = el)}
+            onChange={this.toggleActiveEffect}
           />
         )}
       </>
     );
   }
 
-  connectedCallback() {
-    on('keydown', this.onKeydown, capOpts);
-    on('mousemove', this.savePointE, capOpts);
+  override mounted() {
+    on('keydown', this.onKeydown);
+    on('mousemove', this.savePointE);
     onOpenEditorError(this.showErrorOverlay);
-
-    if (this.state.toggle) {
-      on('toggle', this.toggleActiveEffect, {
-        target: this.state.toggle,
-      });
-    }
   }
 
-  disconnectedCallback() {
-    off('keydown', this.onKeydown, capOpts);
-    off('mousemove', this.savePointE, capOpts);
-    offOpenEditorError(this.showErrorOverlay);
-
-    if (this.state.toggle) {
-      off('toggle', this.toggleActiveEffect, {
-        target: this.state.toggle,
-      });
-    }
-
+  override unmount() {
     this.cleanHandlers();
+    off('keydown', this.onKeydown);
+    off('mousemove', this.savePointE);
+    offOpenEditorError(this.showErrorOverlay);
   }
 
   private savePointE = (e: PointerEvent) => {
@@ -196,6 +181,6 @@ export class HTMLInspectElementConstructor
     on('finish', () => errorOverlay.remove(), {
       target: ani,
     });
-    append(this.shadowRoot, errorOverlay);
+    appendChild(this.shadowRoot, errorOverlay);
   };
 }

--- a/packages/client/src/elements/HTMLOverlayElement/index.tsx
+++ b/packages/client/src/elements/HTMLOverlayElement/index.tsx
@@ -5,19 +5,16 @@ import { SafeAreaObserver } from '../../utils/SafeAreaObserver';
 import { InternalElements, capOpts } from '../../constants';
 import { HTMLCustomElement } from '../HTMLCustomElement';
 
-export class HTMLOverlayElementConstructor
-  extends HTMLCustomElement<{
-    position: HTMLElement;
-    margin: HTMLElement;
-    border: HTMLElement;
-    padding: HTMLElement;
-    content: HTMLElement;
-    tooltip: HTMLTooltipElement;
-    activeEl: HTMLElement | null;
-  }>
-  implements HTMLOverlayElement
-{
-  host() {
+export class HTMLOverlayElement extends HTMLCustomElement<{
+  position: HTMLElement;
+  margin: HTMLElement;
+  border: HTMLElement;
+  padding: HTMLElement;
+  content: HTMLElement;
+  tooltip: HTMLTooltipElement;
+  activeEl: HTMLElement | null;
+}> {
+  override host() {
     return (
       <>
         <link rel="stylesheet" href="./index.css" />
@@ -43,29 +40,21 @@ export class HTMLOverlayElementConstructor
     );
   }
 
-  connectedCallback() {}
-  disconnectedCallback() {}
-
   open = () => {
     this.state.activeEl = null;
     this.state.tooltip.open();
-
     addClass(this.state.position, 'oe-show');
-
+    // Captures scrolling of all elements
     on('scroll', this.updateOverlay, capOpts);
-    on('resize', this.updateOverlay, capOpts);
-
+    on('resize', this.updateOverlay);
     SafeAreaObserver.observe(this.updateOverlay);
   };
 
   close = () => {
     this.state.tooltip.close();
-
     removeClass(this.state.position, 'oe-show');
-
     off('scroll', this.updateOverlay, capOpts);
-    off('resize', this.updateOverlay, capOpts);
-
+    off('resize', this.updateOverlay);
     SafeAreaObserver.unobserve(this.updateOverlay);
   };
 

--- a/packages/client/src/elements/HTMLToggleElement/index.css
+++ b/packages/client/src/elements/HTMLToggleElement/index.css
@@ -20,6 +20,7 @@
   border: none;
   outline: none;
   border-radius: 999px;
+  transition: all 0.1s;
 }
 .oe-active {
   color: var(--cyan);

--- a/packages/client/src/elements/HTMLTooltipElement/index.tsx
+++ b/packages/client/src/elements/HTMLTooltipElement/index.tsx
@@ -15,16 +15,13 @@ import { HTMLCustomElement } from '../HTMLCustomElement';
 
 const offset = 6;
 
-export class HTMLTooltipElementConstructor
-  extends HTMLCustomElement<{
-    root: HTMLElement;
-    el: HTMLElement;
-    comp: HTMLElement;
-    file: HTMLElement;
-  }>
-  implements HTMLTooltipElement
-{
-  host() {
+export class HTMLTooltipElement extends HTMLCustomElement<{
+  root: HTMLElement;
+  el: HTMLElement;
+  comp: HTMLElement;
+  file: HTMLElement;
+}> {
+  override host() {
     return (
       <>
         <link rel="stylesheet" href="./index.css" />
@@ -36,9 +33,6 @@ export class HTMLTooltipElementConstructor
       </>
     );
   }
-
-  connectedCallback() {}
-  disconnectedCallback() {}
 
   open = () => {
     addClass(this.state.root, 'oe-show');
@@ -87,21 +81,20 @@ export class HTMLTooltipElementConstructor
     const { width: rootW, height: rootH } = getDOMRect(this.state.root);
     const { value: safe } = SafeAreaObserver;
 
-    const topArea = box.top > rootH + offset * 2 + safe.top;
-    const posTop = clamp(
-      topArea ? box.top - rootH - offset : box.bottom + offset,
+    const onTopArea = box.top > rootH + offset * 2 + safe.top;
+    const top = clamp(
+      onTopArea ? box.top - rootH - offset : box.bottom + offset,
       offset + safe.top,
       winH - rootH - offset - safe.bottom,
     );
-    const posLeft = clamp(
+    const left = clamp(
       box.left,
       offset + safe.left,
       winW - rootW - offset - safe.right,
     );
-
     applyStyle(this.state.root, {
-      top: CSS_util.px(posTop),
-      left: CSS_util.px(posLeft),
+      top: CSS_util.px(top),
+      left: CSS_util.px(left),
     });
   }
 }

--- a/packages/client/src/elements/index.ts
+++ b/packages/client/src/elements/index.ts
@@ -1,29 +1,26 @@
 import { InternalElements } from '../constants';
-import { HTMLInspectElementConstructor } from './HTMLInspectElement';
-import { HTMLOverlayElementConstructor } from './HTMLOverlayElement';
-import { HTMLToggleElementConstructor } from './HTMLToggleElement';
-import { HTMLTooltipElementConstructor } from './HTMLTooltipElement';
-import { HTMLTreeElementConstructor } from './HTMLTreeElement';
+import { HTMLInspectElement } from './HTMLInspectElement';
+import { HTMLOverlayElement } from './HTMLOverlayElement';
+import { HTMLToggleElement } from './HTMLToggleElement';
+import { HTMLTooltipElement } from './HTMLTooltipElement';
+import { HTMLTreeElement } from './HTMLTreeElement';
 
 export function defineElements() {
   customElements.define(
     InternalElements.HTML_INSPECT_ELEMENT,
-    HTMLInspectElementConstructor,
+    HTMLInspectElement,
   );
   customElements.define(
     InternalElements.HTML_OVERLAY_ELEMENT,
-    HTMLOverlayElementConstructor,
+    HTMLOverlayElement,
   );
   customElements.define(
     InternalElements.HTML_TOGGLE_ELEMENT,
-    HTMLToggleElementConstructor,
+    HTMLToggleElement,
   );
   customElements.define(
     InternalElements.HTML_TOOLTIP_ELEMENT,
-    HTMLTooltipElementConstructor,
+    HTMLTooltipElement,
   );
-  customElements.define(
-    InternalElements.HTML_TREE_ELEMENT,
-    HTMLTreeElementConstructor,
-  );
+  customElements.define(InternalElements.HTML_TREE_ELEMENT, HTMLTreeElement);
 }

--- a/packages/client/src/resolve/creators/createVueResolver.ts
+++ b/packages/client/src/resolve/creators/createVueResolver.ts
@@ -95,7 +95,7 @@ function getAnchor<T = any>(
   const { isValidNext, getSource, getNext } = opts;
 
   let inst = debug.value;
-  let el = debug.originalEl as HTMLElement & Record<string, any>;
+  let el = debug.originalEl as HTMLElement & AnyObject;
   let __source: string | null | undefined;
 
   // find the first el with __source

--- a/packages/client/src/setupClient.tsx
+++ b/packages/client/src/setupClient.tsx
@@ -1,4 +1,4 @@
-import { append } from './utils/ui';
+import { appendChild } from './utils/ui';
 import { defineElements } from './elements';
 import { CLIENT, InternalElements } from './constants';
 import { Options, setOptions } from './options';
@@ -8,6 +8,6 @@ export function setupClient(userOpts: Options) {
   if (!document.querySelector(InternalElements.HTML_INSPECT_ELEMENT)) {
     setOptions(userOpts);
     defineElements();
-    append(document.body, <InternalElements.HTML_INSPECT_ELEMENT />);
+    appendChild(document.body, <InternalElements.HTML_INSPECT_ELEMENT />);
   }
 }

--- a/packages/client/src/utils/setupListeners.ts
+++ b/packages/client/src/utils/setupListeners.ts
@@ -15,6 +15,35 @@ export interface SetupListenersOptions {
   onExitInspect(): void;
 }
 
+const events = [
+  // mouse
+  'mousedown',
+  'mouseenter',
+  'mouseleave',
+  'mousemove',
+  'mouseout',
+  'mouseover',
+  'mouseup',
+  // touch
+  'touchstart',
+  'touchend',
+  'touchcancel',
+  'touchmove',
+  // pointer
+  'pointercancel',
+  'pointerdown',
+  'pointerenter',
+  'pointerleave',
+  'pointermove',
+  'pointerout',
+  'pointerover',
+  'pointerup',
+  // reset
+  'dbclick',
+  'submit',
+  'reset',
+];
+
 export function setupListeners(opts: SetupListenersOptions) {
   const onChangeElement = cleanHoldElementHOC(opts.onChangeElement);
   const onOpenEditor = cleanHoldElementHOC(opts.onOpenEditor);
@@ -22,7 +51,6 @@ export function setupListeners(opts: SetupListenersOptions) {
   const onExitInspect = cleanHoldElementHOC(opts.onExitInspect);
 
   const { once } = getOptions();
-  const events = getSilentEvents();
 
   function setupEventListeners() {
     events.forEach((event) => on(event, onSilent, capOpts));
@@ -77,8 +105,6 @@ export function setupListeners(opts: SetupListenersOptions) {
   }
 
   function onInspect(e: PointerEvent) {
-    onSilent(e);
-
     const el = <HTMLElement>e.target;
     if (checkHoldElement(el)) {
       if (once) onExitInspect();
@@ -105,35 +131,4 @@ export function setupListeners(opts: SetupListenersOptions) {
   }
 
   return setupEventListeners();
-}
-
-function getSilentEvents() {
-  return [
-    // mouse
-    'mousedown',
-    'mouseenter',
-    'mouseleave',
-    'mousemove',
-    'mouseout',
-    'mouseover',
-    'mouseup',
-    // touch
-    'touchstart',
-    'touchend',
-    'touchcancel',
-    'touchmove',
-    // pointer
-    'pointercancel',
-    'pointerdown',
-    'pointerenter',
-    'pointerleave',
-    'pointermove',
-    'pointerout',
-    'pointerover',
-    'pointerup',
-    // reset
-    'dbclick',
-    'submit',
-    'reset',
-  ];
 }

--- a/packages/client/src/utils/ui/dom.ts
+++ b/packages/client/src/utils/ui/dom.ts
@@ -5,14 +5,14 @@ export function getHtml() {
   return document.documentElement;
 }
 
-export function applyAttrs(el: HTMLElement, attrs: Record<string, unknown>) {
-  for (const property of Object.keys(attrs)) {
-    const attr = attrs[property];
+export function applyAttrs(el: HTMLElement, attrs: AnyObject) {
+  for (const prop of Object.keys(attrs)) {
+    const val = attrs[prop];
     // support '' | 0 | false
-    if (attr != null) {
-      el.setAttribute(property, String(attr));
+    if (val != null) {
+      el.setAttribute(prop, val);
     } else {
-      el.removeAttribute(property);
+      el.removeAttribute(prop);
     }
   }
 }
@@ -27,16 +27,26 @@ export function getDOMRect(target: HTMLElement): Omit<DOMRect, 'toJSON'> {
   return domRect;
 }
 
-export function append(
-  parent: HTMLElement | ShadowRoot,
+export function appendChild(
+  el: HTMLElement | ShadowRoot,
   ...children: HTMLElement[]
 ) {
   for (const child of children) {
     if (child.tagName === Fragment) {
       // @ts-ignore
-      append(parent, ...child.children);
+      appendChild(el, ...child.children);
     } else {
-      parent.appendChild(child);
+      el.appendChild(child);
     }
   }
+}
+
+export function resetChildren(
+  el: HTMLElement | ShadowRoot,
+  ...children: HTMLElement[]
+) {
+  while (el.firstChild) {
+    el.removeChild(el.firstChild);
+  }
+  appendChild(el, ...children);
 }

--- a/packages/client/src/utils/ui/style.tsx
+++ b/packages/client/src/utils/ui/style.tsx
@@ -1,4 +1,4 @@
-import { append } from './dom';
+import { appendChild } from './dom';
 
 type PartialWithNull<T> = { [P in keyof T]?: T[P] | undefined | null };
 
@@ -38,7 +38,7 @@ export function computedStyle(el: HTMLElement) {
 export function globalStyle(css: string) {
   const style = <style type="text/css">{css}</style>;
   return {
-    mount: () => !style.isConnected && append(document.head, style),
+    mount: () => !style.isConnected && appendChild(document.head, style),
     unmount: () => style.isConnected && style.remove(),
   };
 }

--- a/packages/shared/src/createClient.ts
+++ b/packages/shared/src/createClient.ts
@@ -3,14 +3,12 @@ import { resolvePath } from './resolve';
 
 const clientId = '@open-editor/client/client';
 const syncTemplate = <const>`
-'use client';
 import { setupClient } from './index';
 if (typeof window !== 'undefined') {
   setupClient(__OPTIONS__)
 }
 `;
 const asyncTemplate = <const>` 
-'use client';
 if (typeof window !== 'undefined') {
   import('./index').then(({ setupClient }) => {
     setupClient(__OPTIONS__)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1(rollup@3.28.1)(typescript@5.2.2)
       rollup-plugin-esbuild:
-        specifier: ^5.0.0
-        version: 5.0.0(esbuild@0.19.2)(rollup@3.28.1)
+        specifier: ^6.0.0
+        version: 6.0.0(esbuild@0.19.2)(rollup@3.28.1)
       simple-git-hooks:
         specifier: ^2.9.0
         version: 2.9.0
@@ -285,7 +285,7 @@ importers:
         version: link:../../packages/rollup
       '@rollup/plugin-babel':
         specifier: ^6.0.3
-        version: 6.0.3(@babel/core@7.22.10)(rollup@3.28.1)
+        version: 6.0.3(@babel/core@7.22.10)(@types/babel__core@7.20.2)(rollup@3.28.1)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.4
         version: 25.0.4(rollup@3.28.1)
@@ -315,7 +315,7 @@ importers:
         version: 2.2.0
       unplugin-vue-source:
         specifier: latest
-        version: 0.0.1
+        version: 0.0.3(rollup@3.28.1)
 
   playground/vite-react:
     dependencies:
@@ -362,7 +362,7 @@ importers:
         version: 5.2.2
       unplugin-vue-source:
         specifier: latest
-        version: 0.0.1
+        version: 0.0.3(rollup@3.28.1)
       vite:
         specifier: ^4.4.5
         version: 4.4.7(@types/node@20.5.6)
@@ -420,7 +420,7 @@ importers:
         version: 4.5.5
       unplugin-vue-source:
         specifier: latest
-        version: 0.0.1
+        version: 0.0.3(rollup@3.28.1)
 
 packages:
   /@aashutoshrathi/word-wrap@1.2.6:
@@ -4409,6 +4409,7 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
@@ -4421,6 +4422,7 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
@@ -4433,6 +4435,7 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
@@ -4445,6 +4448,7 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
@@ -4565,28 +4569,6 @@ packages:
       rollup: 3.28.1
     dev: true
 
-  /@rollup/plugin-babel@6.0.3(@babel/core@7.22.10)(rollup@3.28.1):
-    resolution:
-      {
-        integrity: sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==,
-      }
-    engines: { node: '>=14.0.0' }
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/babel__core': ^7.1.9
-      rollup: ^1.20.0||^2.0.0||^3.0.0
-    peerDependenciesMeta:
-      '@types/babel__core':
-        optional: true
-      rollup:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.10
-      '@babel/helper-module-imports': 7.22.5
-      '@rollup/pluginutils': 5.0.4(rollup@3.28.1)
-      rollup: 3.28.1
-    dev: true
-
   /@rollup/plugin-commonjs@25.0.4(rollup@3.28.1):
     resolution:
       {
@@ -4671,6 +4653,24 @@ packages:
     engines: { node: '>=14.0.0' }
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.28.1
+    dev: true
+
+  /@rollup/pluginutils@5.1.0(rollup@3.28.1):
+    resolution:
+      {
+        integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==,
+      }
+    engines: { node: '>=14.0.0' }
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -9186,6 +9186,13 @@ packages:
     resolution:
       {
         integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==,
+      }
+    dev: true
+
+  /es-module-lexer@1.4.1:
+    resolution:
+      {
+        integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==,
       }
     dev: true
 
@@ -15647,22 +15654,21 @@ packages:
       '@babel/code-frame': 7.22.13
     dev: true
 
-  /rollup-plugin-esbuild@5.0.0(esbuild@0.19.2)(rollup@3.28.1):
+  /rollup-plugin-esbuild@6.0.0(esbuild@0.19.2)(rollup@3.28.1):
     resolution:
       {
-        integrity: sha512-1cRIOHAPh8WQgdQQyyvFdeOdxuiyk+zB5zJ5+YOwrZP4cJ0MT3Fs48pQxrZeyZHcn+klFherytILVfE4aYrneg==,
+        integrity: sha512-I4QN5DV8l0+Sb2fFhfBeEM/o0V4Rzxel0I0oxi7J2Jd3ehwWnhUXMPyc1++/lsRMmxrmOcgYtYPwvey1NzwaTA==,
       }
-    engines: { node: '>=14.18.0', npm: '>=8.0.0' }
+    engines: { node: '>=14.18.0' }
     peerDependencies:
-      esbuild: '>=0.10.1'
+      esbuild: '>=0.18.0'
       rollup: ^1.20.0 || ^2.0.0 || ^3.0.0
     dependencies:
       '@rollup/pluginutils': 5.0.4(rollup@3.28.1)
       debug: 4.3.4
-      es-module-lexer: 1.3.0
+      es-module-lexer: 1.4.1
       esbuild: 0.19.2
       joycon: 3.1.1
-      jsonc-parser: 3.2.0
       rollup: 3.28.1
     transitivePeerDependencies:
       - supports-color
@@ -17635,10 +17641,10 @@ packages:
       }
     engines: { node: '>= 0.8' }
 
-  /unplugin-vue-source@0.0.1:
+  /unplugin-vue-source@0.0.3(rollup@3.28.1):
     resolution:
       {
-        integrity: sha512-8KNHn8hICzI9YFJ0b0T6K1y/pj2TdiAdmYeAFNL1Yi7QptjrXjex4vCr893ynttA4eOvS1alD6VmDF+W4x8gjg==,
+        integrity: sha512-THNRZDQUvOtenfB7fI7hkhIWez6x68J9y40BcNWLFA+XPoo2X5Z0U0rPVoD99N1a/Uq+f6TjPqhhhNDeKW5YHQ==,
       }
     engines: { node: '>=14' }
     dependencies:
@@ -17646,10 +17652,12 @@ packages:
       '@babel/parser': 7.22.16
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.22.11)
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.22.11)
+      '@rollup/pluginutils': 5.1.0(rollup@3.28.1)
       '@vue/compiler-dom': 3.3.4
       magic-string: 0.30.5
       unplugin: 1.4.0
     transitivePeerDependencies:
+      - rollup
       - supports-color
     dev: true
 

--- a/scripts/unbuild.ts
+++ b/scripts/unbuild.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'node:path';
-import { OutputOptions, RollupOptions } from 'rollup';
+import { type OutputOptions, type RollupOptions } from 'rollup';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import esbuild from 'rollup-plugin-esbuild';


### PR DESCRIPTION
Simplified the way to bind events, you can now bind events directly through `jsx`.