### PR TITLE
fix: `vueResolver` non-deep find has no results

### DIFF
--- a/packages/client/src/elements/HTMLToggleElement/index.css
+++ b/packages/client/src/elements/HTMLToggleElement/index.css
@@ -14,9 +14,9 @@
   display: none;
 }
 .oe-button {
-  color: var(--text);
-  background: var(--fill);
-  box-shadow: 0 0 1px var(--fill-2);
+  color: var(--text-color);
+  background: var(--bg-color);
+  box-shadow: 0 0 1px var(--bg-color2);
   border: none;
   outline: none;
   border-radius: 999px;

--- a/packages/client/src/elements/HTMLTooltipElement/index.css
+++ b/packages/client/src/elements/HTMLTooltipElement/index.css
@@ -5,11 +5,11 @@
   display: none;
   padding: 12px 20px;
   max-width: calc(100% - 56px);
-  color: var(--text);
+  color: var(--text-color);
   visibility: hidden;
-  background: var(--fill-opt);
-  backdrop-filter: blur(30px);
-  box-shadow: 0 0 1px var(--fill-2);
+  background: var(--bg-color-opt);
+  backdrop-filter: var(--filter-c) blur(20px);
+  box-shadow: 0 0 1px var(--bg-color2);
   border-radius: 12px;
   pointer-events: none;
   will-change: visibility, top, left;
@@ -19,7 +19,7 @@
   font-weight: 500;
 }
 .oe-file {
-  color: var(--text-2);
+  color: var(--text-color2);
   text-decoration: underline;
   word-wrap: break-word;
 }

--- a/packages/client/src/elements/HTMLTreeElement/index.css
+++ b/packages/client/src/elements/HTMLTreeElement/index.css
@@ -17,10 +17,10 @@
   left: 50%;
   z-index: var(--z-index-tree);
   transform: translate(-50%, -50%);
-  color: var(--text);
-  background: var(--fill-opt);
-  backdrop-filter: blur(30px);
-  box-shadow: 0 0 1px var(--fill-2);
+  color: var(--text-color);
+  background: var(--bg-color-opt);
+  backdrop-filter: var(--filter-c) blur(40px);
+  box-shadow: 0 0 1px var(--bg-color2);
   border-radius: 14px;
 }
 .oe-close {
@@ -30,7 +30,7 @@
   padding: 8px;
   width: 32px;
   height: 32px;
-  color: var(--text);
+  color: var(--text-color);
   background: transparent;
   border: none;
   border-radius: 99px;
@@ -82,7 +82,7 @@
   opacity: 0.2;
   width: 1px;
   height: calc(100% - 44px);
-  background: var(--text);
+  background: var(--text-color);
 }
 .oe-tag {
   margin: 2px 0;
@@ -99,7 +99,7 @@
 }
 .oe-file {
   padding-left: 6px;
-  color: var(--text-2);
+  color: var(--text-color2);
   font-size: 12px;
   font-weight: 300;
   text-decoration: underline;

--- a/packages/client/src/resolve/creators/createVueResolver.ts
+++ b/packages/client/src/resolve/creators/createVueResolver.ts
@@ -25,17 +25,17 @@ export function createVueResolver<T = any>(opts: VueResolverOptions<T>) {
     while (isValid(inst)) {
       const file = getFile(inst);
       if (isValidFileName(file)) {
-        const parsedFile = parseVueSource(file);
+        const parsedFile = parseSource(file);
         if (source) {
-          const parsedSource = parseVueSource(source);
+          const parsedSource = parseSource(source);
           if (parsedSource.file === parsedFile.file) {
             push(inst, parsedSource, () => (source = getSource(inst)));
+            if (!deep) return;
           }
         } else {
           push(inst, parsedFile);
+          if (!deep) return;
         }
-
-        if (!deep) return;
       }
 
       inst = getNext(inst);
@@ -65,7 +65,7 @@ function getAnchor<T = any>(
   return [debug.value, getSource(debug.value)];
 }
 
-function parseVueSource(source: string) {
+function parseSource(source: string) {
   const [file, line = 1, column = 1] = source.split(':', 3);
   return {
     file: ensureFileName(file),

--- a/packages/client/src/resolve/resolves/vue2.ts
+++ b/packages/client/src/resolve/resolves/vue2.ts
@@ -17,8 +17,8 @@ export function resolveVue2(
 let resolver: ReturnType<typeof createVueResolver<any>>;
 function ensureLazyResolver() {
   return (resolver ||= createVueResolver({
-    isValid(inst) {
-      return Boolean(inst?.$vnode);
+    isValid(inst): inst is any {
+      return !!inst?.$vnode;
     },
     getNext,
     getSource,

--- a/packages/client/src/resolve/resolves/vue3.ts
+++ b/packages/client/src/resolve/resolves/vue3.ts
@@ -14,8 +14,8 @@ export function resolveVue3(
 let resolver: ReturnType<typeof createVueResolver<ComponentInternalInstance>>;
 function ensureLazyResolver() {
   return (resolver ||= createVueResolver({
-    isValid(inst) {
-      return Boolean(inst);
+    isValid(inst): inst is any {
+      return !!inst;
     },
     getNext,
     getSource,

--- a/packages/client/src/setupClient.tsx
+++ b/packages/client/src/setupClient.tsx
@@ -1,13 +1,7 @@
-if (typeof window === 'undefined') {
-  throw Error(
-    '@open-editor/client: Does not support running on the server side.',
-  );
-}
-
 import { appendChild } from './utils/ui';
 import { defineElements } from './elements';
 import { InternalElements } from './constants';
-import { Options, setOptions } from './options';
+import { type Options, setOptions } from './options';
 
 export function setupClient(userOpts: Options) {
   if (!document.querySelector(InternalElements.HTML_INSPECT_ELEMENT)) {

--- a/packages/client/src/utils/getColorMode.ts
+++ b/packages/client/src/utils/getColorMode.ts
@@ -2,27 +2,29 @@ import { getOptions } from '../options';
 
 const LightColors = postcss`
 :host {
-  --text: #000000;
-  --text-2: #222222;
-  --fill: #f6f7f8;
-  --fill-opt: #f6f7f866;
-  --fill-2: #c6c7c8;
+  --text-color: #000000;
+  --text-color2: #222222;
+  --bg-color: #fffffe;
+  --bg-color-opt: #fffffe88;
+  --bg-color2: #bfbfbe;
   --cyan: #2dd9da;
   --red: #ff335c;
   --red-light: #ff335c33;
+  --filter-c: contrast(0.9);
 }
 `;
 
 const DarkColors = postcss`
 :host {
-  --text: #ffffff;
-  --text-2: #dddddd;
-  --fill: #292a2d;
-  --fill-opt: #292a2d88;
-  --fill-2: #595a5d;
+  --text-color: #ffffff;
+  --text-color2: #dddddd;
+  --bg-color: #292a2d;
+  --bg-color-opt: #292a2d88;
+  --bg-color2: #696a6d;
   --cyan: #4df9fa;
   --red: #ff335c;
   --red-light: #ff335c33;
+  --filter-c: contrast(0.8);
 }
 `;
 

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'rollup';
+import { type Plugin } from 'rollup';
 import { resolve } from 'node:path';
 import { createClient, isDev } from '@open-editor/shared/node';
 import { isObj, isStr } from '@open-editor/shared';

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,8 +1,5 @@
-import { setupServer, Options } from './setupServer';
-import {
+export { type Options, setupServer } from './setupServer';
+export {
+  type OpenEditorMiddlewareOptions,
   openEditorMiddleware,
-  OpenEditorMiddlewareOptions,
 } from './openEditorMiddleware';
-
-export type { Options, OpenEditorMiddlewareOptions };
-export { setupServer, openEditorMiddleware };

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -64,17 +64,16 @@ export default class OpenEditorPlugin {
         }).apply(compiler);
       });
     } else {
-      compiler.options.module.rules.push({
-        test: /\.mjs$/,
-        type: 'javascript/auto',
-        include: /open-editor/,
-      });
-
       const entry = compiler.options.entry;
       compiler.options.entry = () =>
         this.resolveClient((clientEntry) => {
           return this.injectClient(entry, clientEntry);
         });
+      compiler.options.module.rules.push({
+        test: /\.mjs$/,
+        type: 'javascript/auto',
+        include: /open-editor/,
+      });
       compiler.hooks.entryOption.call(
         compiler.options.context!,
         compiler.options.entry,

--- a/scripts/postcss.ts
+++ b/scripts/postcss.ts
@@ -17,8 +17,9 @@ export interface Options {
   sourcemap?: boolean;
 }
 
+let processor: postcss.Processor;
 export default function postssPlugin(options: Options): RollupPlugin {
-  const processor = postcss(autoprefixer(), <postcss.Plugin>minifySelectors());
+  processor ||= postcss(autoprefixer(), <postcss.Plugin>minifySelectors());
 
   function process(raw: string) {
     const css = processor


### PR DESCRIPTION
When `vueResolver` looks for code source file information in a non-deep environment, an error is returned, resulting in incorrect results. This is now fixed.

Additionally some variables have been renamed.