### PR TITLE
feat: Update the position of `overlay` in real time

### DIFF
--- a/.changeset/fresh-cougars-grow.md
+++ b/.changeset/fresh-cougars-grow.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Update `overlay` in real time

--- a/packages/client/src/elements/HTMLCustomElement.ts
+++ b/packages/client/src/elements/HTMLCustomElement.ts
@@ -3,8 +3,8 @@ import { resetChildren } from '../utils/ui';
 export abstract class HTMLCustomElement<
   State extends AnyObject = AnyObject,
 > extends HTMLElement {
-  readonly shadowRoot!: ShadowRoot;
-  protected readonly state: State;
+  readonly shadowRoot: ShadowRoot = undefined as unknown as ShadowRoot;
+  protected readonly state: State = undefined as unknown as State;
 
   public constructor(state: Partial<State> = {}) {
     super();

--- a/packages/client/src/utils/openEditor.ts
+++ b/packages/client/src/utils/openEditor.ts
@@ -61,8 +61,8 @@ export function offOpenEditorError(listener: Listener) {
 }
 
 class OpenEditorError extends Error {
-  openURL: URL;
-  response?: Response;
+  openURL: URL = undefined as unknown as URL;
+  response?: Response = undefined;
   constructor(message: string, openURL: URL, response?: Response) {
     super(message);
     this.openURL = openURL;

--- a/scripts/unbuild.ts
+++ b/scripts/unbuild.ts
@@ -89,6 +89,9 @@ function buildBundles(
           minifySyntax: !__DEV__,
           minifyWhitespace: !__DEV__,
           jsxImportSource: join(clientRoot, './jsx'),
+          supported: {
+            'class-field': true,
+          },
         }),
       ],
     };


### PR DESCRIPTION
Use `requestAnimationFrame` to update the position of `overlay` in real time. This approach allows the position changes caused by page re-rendering to be observed.