### PR TITLE
fix: Clear inspect when mouse enters `iframe`

### DIFF
--- a/.changeset/hip-chicken-brake.md
+++ b/.changeset/hip-chicken-brake.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Clear inspect when mouse enters `iframe`

--- a/packages/client/src/resolve/creators/createReactResolver.ts
+++ b/packages/client/src/resolve/creators/createReactResolver.ts
@@ -17,25 +17,21 @@ export function createReactResolver<T = any>(opts: ReactResolverOptions<T>) {
     deep: boolean,
   ) {
     while (cur) {
-      let next = getNext(cur);
-
       const source = getSource(cur);
+      let next = getNext(cur);
       if (isValidFileName(source?.fileName)) {
         while (!isValid(next)) {
           if (!next) return;
           next = getNext(next);
         }
-
         tree.push({
           name: getName(next!),
           file: source.fileName,
           line: source.lineNumber,
           column: source.columnNumber,
         });
-
         if (!deep) return;
       }
-
       cur = next;
     }
   };

--- a/packages/client/src/resolve/creators/createVueResolver.ts
+++ b/packages/client/src/resolve/creators/createVueResolver.ts
@@ -18,10 +18,8 @@ export function createVueResolver<T = any>(opts: VueResolverOptions<T>) {
     deep: boolean,
   ) {
     const { isValid, getNext, getSource, getFile, getName } = opts;
-
     const fileSet = new Set<string>();
     let [inst, source] = getAnchor(debug, getSource);
-
     while (isValid(inst)) {
       const file = getFile(inst);
       if (isValidFileName(file)) {
@@ -37,16 +35,15 @@ export function createVueResolver<T = any>(opts: VueResolverOptions<T>) {
           if (!deep) return;
         }
       }
-
       inst = getNext(inst);
     }
 
-    function push(inst: any, source: any, done?: () => void) {
-      if (!fileSet.has(source.file)) {
-        fileSet.add(source.file);
+    function push(inst: any, meta: any, done?: () => void) {
+      if (!fileSet.has(meta.file)) {
+        fileSet.add(meta.file);
         tree.push({
-          name: getName(inst) ?? getNameByFile(source.file),
-          ...source,
+          name: getName(inst) ?? getNameByFile(meta.file),
+          ...meta,
         });
         done?.();
       }

--- a/packages/client/src/resolve/resolveDebug.ts
+++ b/packages/client/src/resolve/resolveDebug.ts
@@ -1,7 +1,6 @@
 import { isValidElement } from '../utils/isValidElement';
 
 export type ResolveDebug<T = any> = {
-  originalEl: HTMLElement;
   el: HTMLElement;
   key: string;
   value?: T | null;
@@ -19,12 +18,11 @@ export const vue2Key = '__vue__';
 
 // support parsing single project multiple frameworks
 export function resolveDebug(el: HTMLElement): ResolveDebug | undefined {
-  const originalEl = el;
   while (isValidElement(el)) {
     const key = findKey(el);
     if (key) {
       const value = (<any>el)[key];
-      if (value) return { originalEl, el, key, value };
+      if (value) return { el, key, value };
     }
     el = el.parentElement!;
   }
@@ -41,18 +39,18 @@ function findKey(el: HTMLElement) {
   }
 
   // react17+
-  react17PlusKey ||= findStartsWith(el, react17PlusKeyStarts);
+  react17PlusKey ||= startsWith(el, react17PlusKeyStarts);
   if (react17PlusKey && react17PlusKey in el) {
     return react17PlusKey;
   }
 
   // react15+
-  react15PlusKey ||= findStartsWith(el, react15PlusKeyStarts);
+  react15PlusKey ||= startsWith(el, react15PlusKeyStarts);
   if (react15PlusKey && react15PlusKey in el) {
     return react15PlusKey;
   }
 }
 
-function findStartsWith(el: HTMLElement, starts: string) {
+function startsWith(el: HTMLElement, starts: string) {
   return Object.keys(el).find((key) => key.startsWith(starts));
 }

--- a/packages/client/src/utils/setupListeners.ts
+++ b/packages/client/src/utils/setupListeners.ts
@@ -99,7 +99,10 @@ export function setupListeners(opts: SetupListenersOptions) {
 
   function onLeaveScreen(e: PointerEvent) {
     // On PC devices, focus is lost when the mouse leaves the browser window
-    if (e.pointerType === 'mouse' && e.relatedTarget == null) {
+    if (
+      e.pointerType === 'mouse' &&
+      !isValidElement(<HTMLElement>e.relatedTarget)
+    ) {
       onChangeElement((activeEl = null));
     }
   }


### PR DESCRIPTION
When the mouse enters the `iframe` element, the inspection status of the inspector needs to be cleared.