### PR TITLE
fix: mouse position information loss

### DIFF
--- a/.changeset/red-buses-notice.md
+++ b/.changeset/red-buses-notice.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Fix mouse position information loss

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Whether you are a `React` developer, a `Vue` developer, or a `React` and `Vue` d
 
 > The example uses [`vite/react`](https://github.com/zjxxxxxxxxx/open-editor/tree/main/playground/vite-react) as a reference. In other cases, the only choice is different, and the usage is exactly the same.
 
-First you need to install the plugin.
+First you need to install the plugin into the project.
 
 ```bash
-npm -D i @open-editor/vite
+npm i @open-editor/vite -D
 ```
 
 Then add the plugin to the build configuration.
@@ -80,8 +80,6 @@ export default defineConfig({
   ],
 });
 ```
-
-That concludes the code section.
 
 ### Enable inspector
 
@@ -162,3 +160,4 @@ window.addEventListener('openeditor', (e) => {
 
 - [react-dev-inspector](https://github.com/zthxxx/react-dev-inspector)
 - [vite-plugin-vue-inspector](https://github.com/webfansplz/vite-plugin-vue-inspector)
+- [launch-editor](https://github.com/yyx990803/launch-editor)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,13 +53,13 @@
 
 > 示例以 [`vite/react`](https://github.com/zjxxxxxxxxx/open-editor/tree/main/playground/vite-react) 作为参考，其他情况下只是选择不同而已，使用方式是完全一致的。
 
-首先需要把插件安装一下。
+首先需要将插件安装到项目中。
 
 ```bash
-npm -D i @open-editor/vite
+npm i @open-editor/vite -D
 ```
 
-然后把插件添加到编译配置中。
+然后将插件添加到编译配置中。
 
 ```ts
 // vite.config.ts
@@ -80,8 +80,6 @@ export default defineConfig({
   ],
 });
 ```
-
-到这里代码部分就已经介绍完了。
 
 ### 启用检查器
 
@@ -162,3 +160,4 @@ window.addEventListener('openeditor', (e) => {
 
 - [react-dev-inspector](https://github.com/zthxxx/react-dev-inspector)
 - [vite-plugin-vue-inspector](https://github.com/webfansplz/vite-plugin-vue-inspector)
+- [launch-editor](https://github.com/yyx990803/launch-editor)

--- a/packages/client/jsx/jsx-runtime.js
+++ b/packages/client/jsx/jsx-runtime.js
@@ -16,7 +16,7 @@ function jsx(type, props) {
     : document.createElement(type);
 
   if (children != null) {
-    appendChildren(el, Array.isArray(children) ? children : [children]);
+    appendChildren(el, toArray(children));
   }
 
   if (type !== FRAGMENT_TYPE) {
@@ -38,12 +38,14 @@ function jsx(type, props) {
   return el;
 }
 
+const toArray = [].concat.bind([]);
+
 const onRE = /^on([A-Z])/;
 function isOn(val) {
   return onRE.test(val);
 }
 function typed(val) {
-  return val.replace(onRE, (_, c) => c).toLowerCase();
+  return val.replace(onRE, '$1').toLowerCase();
 }
 
 const textRE = /(string|number)/;

--- a/packages/client/src/elements/HTMLInspectElement/index.tsx
+++ b/packages/client/src/elements/HTMLInspectElement/index.tsx
@@ -15,7 +15,7 @@ import {
   openEditor,
 } from '../../utils/openEditor';
 import { getColorMode } from '../../utils/getColorMode';
-import { InternalElements } from '../../constants';
+import { InternalElements, capOpts } from '../../constants';
 import { getOptions } from '../../options';
 import { resolveSource } from '../../resolve';
 import { HTMLCustomElement } from '../HTMLCustomElement';
@@ -92,14 +92,15 @@ export class HTMLInspectElement extends HTMLCustomElement<{
 
   override mounted() {
     on('keydown', this.onKeydown);
-    on('mousemove', this.savePointE);
+    // Capture mouse position to prevent `stopPropagation`
+    on('mousemove', this.savePointE, capOpts);
     onOpenEditorError(this.showErrorOverlay);
   }
 
   override unmount() {
     this.cleanHandlers();
     off('keydown', this.onKeydown);
-    off('mousemove', this.savePointE);
+    off('mousemove', this.savePointE, capOpts);
     offOpenEditorError(this.showErrorOverlay);
   }
 

--- a/packages/client/src/elements/HTMLTreeElement/index.css
+++ b/packages/client/src/elements/HTMLTreeElement/index.css
@@ -9,6 +9,7 @@
   z-index: var(--z-index-tree);
   width: 100vw;
   height: 100vh;
+  background: var(--bg-color2-opt);
   backdrop-filter: blur(10px);
 }
 .oe-popup {
@@ -21,7 +22,7 @@
   background: var(--bg-color-opt);
   backdrop-filter: var(--filter);
   box-shadow: 0 0 1px var(--bg-color2);
-  border-radius: 14px;
+  border-radius: 16px;
 }
 .oe-close {
   position: absolute;

--- a/packages/client/src/utils/holdElement.ts
+++ b/packages/client/src/utils/holdElement.ts
@@ -25,7 +25,7 @@ export function setupHoldElement(e: Event) {
   }
 }
 
-export function cleanHoldElementHOC<T extends (...args: any[]) => any>(fn: T) {
+export function withCleanHoldElement<T extends (...args: any[]) => any>(fn: T) {
   function wrapped(...args: Parameters<T>): ReturnType<T> {
     cleanHoldElement();
     return fn(...args);

--- a/packages/client/src/utils/setupListeners.ts
+++ b/packages/client/src/utils/setupListeners.ts
@@ -5,7 +5,7 @@ import { isValidElement } from './isValidElement';
 import {
   checkHoldElement,
   setupHoldElement,
-  cleanHoldElementHOC,
+  withCleanHoldElement,
 } from './holdElement';
 
 export interface SetupListenersOptions {
@@ -45,10 +45,10 @@ const events = [
 ];
 
 export function setupListeners(opts: SetupListenersOptions) {
-  const onChangeElement = cleanHoldElementHOC(opts.onChangeElement);
-  const onOpenEditor = cleanHoldElementHOC(opts.onOpenEditor);
-  const onOpenTree = cleanHoldElementHOC(opts.onOpenTree);
-  const onExitInspect = cleanHoldElementHOC(opts.onExitInspect);
+  const onChangeElement = withCleanHoldElement(opts.onChangeElement);
+  const onOpenEditor = withCleanHoldElement(opts.onOpenEditor);
+  const onOpenTree = withCleanHoldElement(opts.onOpenTree);
+  const onExitInspect = withCleanHoldElement(opts.onExitInspect);
 
   const { once } = getOptions();
 

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -59,6 +59,8 @@ interface Options {
   once?: boolean;
   /**
    * custom openEditor handler
+   *
+   * @default 'launch-editor'
    */
   onOpenEditor?(file: string): void;
 }

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -11,30 +11,28 @@ export interface Options {
    * @default process.cwd()
    */
   rootDir?: string;
-
   /**
    * render the toggle into the browser
    *
    * @default true
    */
   displayToggle?: boolean;
-
   /**
    * set UI color mode
    *
    * @default 'system'
    */
   colorMode?: 'system' | 'light' | 'dark';
-
   /**
    * exit the check after opening the editor or component tree
    *
    * @default true
    */
   once?: boolean;
-
   /**
    * custom openEditor handler
+   *
+   * @default 'launch-editor'
    */
   onOpenEditor?(file: string): void;
 }

--- a/packages/server/src/openEditorMiddleware.ts
+++ b/packages/server/src/openEditorMiddleware.ts
@@ -11,9 +11,10 @@ export interface OpenEditorMiddlewareOptions {
    * @default process.cwd()
    */
   rootDir?: string;
-
   /**
    * custom openEditor handler
+   *
+   * @default 'launch-editor'
    */
   onOpenEditor?(file: string): void;
 }

--- a/packages/server/src/setupServer.ts
+++ b/packages/server/src/setupServer.ts
@@ -8,9 +8,10 @@ export interface Options {
    * @default process.cwd()
    */
   rootDir?: string;
-
   /**
    * custom openEditor handler
+   *
+   * @default 'launch-editor'
    */
   onOpenEditor?(file: string): void;
 }

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -59,6 +59,8 @@ interface Options {
   once?: boolean;
   /**
    * custom openEditor handler
+   *
+   * @default 'launch-editor'
    */
   onOpenEditor?(file: string): void;
 }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -11,30 +11,28 @@ export interface Options {
    * @default process.cwd()
    */
   rootDir?: string;
-
   /**
    * render the toggle into the browser
    *
    * @default true
    */
   displayToggle?: boolean;
-
   /**
    * set UI color mode
    *
    * @default 'system'
    */
   colorMode?: 'system' | 'light' | 'dark';
-
   /**
    * exit the check after opening the editor or component tree
    *
    * @default true
    */
   once?: boolean;
-
   /**
    * custom openEditor handler
+   *
+   * @default 'launch-editor'
    */
   onOpenEditor?(file: string): void;
 }

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -59,6 +59,8 @@ interface Options {
   once?: boolean;
   /**
    * custom openEditor handler
+   *
+   * @default 'launch-editor'
    */
   onOpenEditor?(file: string): void;
 }

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -10,30 +10,28 @@ export interface Options {
    * @default process.cwd()
    */
   rootDir?: string;
-
   /**
    * render the toggle into the browser
    *
    * @default true
    */
   displayToggle?: boolean;
-
   /**
    * set UI color mode
    *
    * @default 'system'
    */
   colorMode?: 'system' | 'light' | 'dark';
-
   /**
    * exit the check after opening the editor or component tree
    *
    * @default true
    */
   once?: boolean;
-
   /**
    * custom openEditor handler
+   *
+   * @default 'launch-editor'
    */
   onOpenEditor?(file: string): void;
 }


### PR DESCRIPTION
Since the `mousemove` event stops bubbling when the inspector is enabled, the event listener that records the mouse position cannot be triggered. Now set the event listener that records the mouse position to `capture` to solve this problem.