### PR TITLE
feat: Add `disableHoverCSS` option

### DIFF
--- a/.changeset/lazy-chefs-relax.md
+++ b/.changeset/lazy-chefs-relax.md
@@ -1,0 +1,8 @@
+---
+'@open-editor/webpack': minor
+'@open-editor/client': minor
+'@open-editor/rollup': minor
+'@open-editor/vite': minor
+---
+
+Add `disableHoverCSS` option

--- a/.changeset/plenty-camels-greet.md
+++ b/.changeset/plenty-camels-greet.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': minor
+---
+
+Add `enableinspector` and `exitinspector` event

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Whether you are a `React` developer, a `Vue` developer, or a `React` and `Vue` d
 
 > Requires React version 15+.
 
-`open-editor` needs to be used with [`@babel/plugin-transform-react-jsx-source`](https://babeljs.io/docs/babel-plugin-transform-react-jsx-source), which is a plug-in for getting source code line and column information. Usually you don't have to pay attention to this thing because it is mainly built into the scaffolding tool. If you encounter the problem that `open-editor` cannot open the code editor, this will It will be a way to troubleshoot the problem.
+`open-editor` needs to be used with [`@babel/plugin-transform-react-jsx-source`](https://babeljs.io/docs/babel-plugin-transform-react-jsx-source), which is a plugin for getting source code line and column information. Usually you don't have to pay attention to this thing because it is mainly built into the scaffolding tool. If you encounter the problem that `open-editor` cannot open the code editor, this will It will be a way to troubleshoot the problem.
 
 ### Vue
 
 > Requires Vue version 2+.
 
-`open-editor` needs to be used with [`unplugin-vue-source`](https://github.com/zjxxxxxxxxx/unplugin-vue-source), which is a plugin for getting source code line and column information , if this plug-in is missing, the source code file will only be opened in the code editor, but line and column cannot be located.
+`open-editor` needs to be used with [`unplugin-vue-source`](https://github.com/zjxxxxxxxxx/unplugin-vue-source), which is a plugin for getting source code line and column information , if this plugin is missing, the source code file will only be opened in the code editor, but line and column cannot be located.
 
 ### Use plugin
 
@@ -116,6 +116,46 @@ Then click on the tree node to automatically open the source code file in the co
 Click again (shortcut key 1: ⌨️ <kbd>option ⌥</kbd> + <kbd>command ⌘</kbd> + <kbd>O</kbd>, shortcut key 2: ⌨️ <kbd>esc</kbd>, shortcut key 3: 🖱 right-click) the switch button in the upper right corner of the browser to exit the inspector.
 
 <img width="500" src="./public/toggle-button-demo2.png" alt="toggle button demo"/>
+
+## `enableinspector` event
+
+The default behavior of enable inspector can be changed by subscribing to the `enableinspector` event.
+
+### Prevent default behavior
+
+```ts
+window.addEventListener('enableinspector', (e) => {
+  e.preventDefault();
+});
+```
+
+### Add additional handler
+
+```ts
+window.addEventListener('enableinspector', (e) => {
+  console.log('enable inspector');
+});
+```
+
+## `exitinspector` event
+
+The default behavior of exit inspector can be changed by subscribing to the `exitinspector` event.
+
+### Prevent default behavior
+
+```ts
+window.addEventListener('exitinspector', (e) => {
+  e.preventDefault();
+});
+```
+
+### Add additional handler
+
+```ts
+window.addEventListener('exitinspector', (e) => {
+  console.log('exit inspector');
+});
+```
 
 ## `openeditor` event
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -117,6 +117,46 @@ npm run dev
 
 <img width="500" src="./public/toggle-button-demo2.png" alt="toggle button demo"/>
 
+## `enableinspector` 事件
+
+可以通过订阅 `enableinspector` 事件改变启用检查器的默认行为。
+
+### 阻止默认行为
+
+```ts
+window.addEventListener('enableinspector', (e) => {
+  e.preventDefault();
+});
+```
+
+### 添加额外的处理程序
+
+```ts
+window.addEventListener('enableinspector', (e) => {
+  console.log('enable inspector');
+});
+```
+
+## `exitinspector` 事件
+
+可以通过订阅 `exitinspector` 事件改变退出检查器的默认行为。
+
+### 阻止默认行为
+
+```ts
+window.addEventListener('exitinspector', (e) => {
+  e.preventDefault();
+});
+```
+
+### 添加额外的处理程序
+
+```ts
+window.addEventListener('exitinspector', (e) => {
+  console.log('exit inspector');
+});
+```
+
 ## `openeditor` 事件
 
 可以通过订阅 `openeditor` 事件改变打开编辑器的默认行为。

--- a/packages/client/jsx/jsx-runtime.js
+++ b/packages/client/jsx/jsx-runtime.js
@@ -25,8 +25,8 @@ function jsx(type, props) {
     for (const prop of Object.keys(attrs)) {
       const val = attrs[prop];
       if (val != null) {
-        if (isOn(prop)) {
-          on(typed(prop), val, { target: el });
+        if (isEventType(prop)) {
+          on(toNativeType(prop), val, { target: el });
         } else {
           el.setAttribute(prop, val);
         }
@@ -40,12 +40,13 @@ function jsx(type, props) {
 
 const toArray = [].concat.bind([]);
 
-const onRE = /^on([A-Z])/;
-function isOn(val) {
-  return onRE.test(val);
+const eventRE = /^on[A-Z]/;
+function isEventType(val) {
+  return eventRE.test(val);
 }
-function typed(val) {
-  return val.replace(onRE, '$1').toLowerCase();
+
+function toNativeType(val) {
+  return val.substr(2).toLowerCase();
 }
 
 const textRE = /(string|number)/;

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -6,8 +6,4 @@ export const InternalElements = <const>{
   HTML_TREE_ELEMENT: 'oe-tree',
 };
 
-export const capOpts = {
-  capture: true,
-};
-
 export const CACHE_POS_TOP_ID = '__oe_pt__';

--- a/packages/client/src/elements/HTMLInspectElement/index.css
+++ b/packages/client/src/elements/HTMLInspectElement/index.css
@@ -2,7 +2,7 @@
   --red: #ff335c;
   --red-light: #ff335c33;
   --shadow: 0 0 1px var(--bg-color2);
-  --filter: saturate(1.2) blur(10px);
+  --filter: saturate(1.2) blur(12px);
 
   --overlay-margin: #f6b26ba8;
   --overlay-border: #ffe599a8;

--- a/packages/client/src/elements/HTMLOverlayElement/index.tsx
+++ b/packages/client/src/elements/HTMLOverlayElement/index.tsx
@@ -63,7 +63,6 @@ export class HTMLOverlayElement extends HTMLCustomElement<{
 
   update(el: HTMLElement | null) {
     this.state.activeEl = el;
-    this.updateOverlay();
   }
 
   private startObserver() {
@@ -77,12 +76,10 @@ export class HTMLOverlayElement extends HTMLCustomElement<{
 
   private observe() {
     if (this.state.observing) {
-      if (this.state.activeEl) {
-        if (!this.state.activeEl.isConnected) {
-          this.state.activeEl = null;
-        }
-        this.updateOverlay();
+      if (this.state.activeEl?.isConnected === false) {
+        this.state.activeEl = null;
       }
+      this.updateOverlay();
       requestAnimationFrame(this.observe);
     }
   }

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -18,6 +18,12 @@ export interface Options {
    */
   colorMode?: 'system' | 'light' | 'dark';
   /**
+   * Disable hover effect from CSS when inspector is enabled
+   *
+   * @default false
+   */
+  disableHoverCSS?: boolean;
+  /**
    * exit the check after opening the editor or component tree
    *
    * @default true
@@ -40,6 +46,7 @@ export function setOptions(
     ...userOpts,
     displayToggle: userOpts.displayToggle ?? true,
     colorMode: userOpts.colorMode ?? 'system',
+    disableHoverCSS: userOpts.disableHoverCSS ?? false,
     once: userOpts.once ?? true,
   };
 }

--- a/packages/client/src/utils/setupListeners.ts
+++ b/packages/client/src/utils/setupListeners.ts
@@ -1,7 +1,6 @@
-import { capOpts } from '../constants';
 import { getOptions } from '../options';
 import { off, on } from './event';
-import { checkValidElement, checkVisibility } from './ui';
+import { checkValidElement } from './ui';
 import {
   checkClickedElement,
   setupClickedElementAttrs,
@@ -55,30 +54,60 @@ export function setupListeners(opts: SetupListenersOptions) {
   let activeEl: HTMLElement | null;
 
   function setupEventListeners() {
-    events.forEach((event) => on(event, onSilent, capOpts));
+    events.forEach((event) => on(event, onSilent, { capture: true }));
 
     // The click event on the window does not run, but the click event on the document does.
-    on('click', onInspect, { ...capOpts, target: document });
-    on('pointerdown', setupClickedElementAttrs, capOpts);
-    on('pointermove', onActiveElement, capOpts);
-    on('pointerover', onEnterScreen, capOpts);
-    on('pointerout', onLeaveScreen, capOpts);
-    on('longpress', onInspect, capOpts);
-    on('quickexit', onExitInspect, capOpts);
+    on('click', onInspect, {
+      capture: true,
+      target: document,
+    });
+    on('pointerdown', setupClickedElementAttrs, {
+      capture: true,
+    });
+    on('pointermove', onActiveElement, {
+      capture: true,
+    });
+    on('pointerover', onEnterScreen, {
+      capture: true,
+    });
+    on('pointerout', onLeaveScreen, {
+      capture: true,
+    });
+    on('longpress', onInspect, {
+      capture: true,
+    });
+    on('quickexit', onExitInspect, {
+      capture: true,
+    });
 
     return cleanEventListeners;
   }
 
   function cleanEventListeners() {
-    events.forEach((event) => off(event, onSilent, capOpts));
+    events.forEach((event) => off(event, onSilent, { capture: true }));
 
-    off('click', onInspect, { ...capOpts, target: document });
-    off('pointerdown', setupClickedElementAttrs, capOpts);
-    off('pointermove', onActiveElement, capOpts);
-    off('pointerover', onEnterScreen, capOpts);
-    off('pointerout', onLeaveScreen, capOpts);
-    off('longpress', onInspect, capOpts);
-    off('quickexit', onExitInspect, capOpts);
+    off('click', onInspect, {
+      capture: true,
+      target: document,
+    });
+    off('pointerdown', setupClickedElementAttrs, {
+      capture: true,
+    });
+    off('pointermove', onActiveElement, {
+      capture: true,
+    });
+    off('pointerover', onEnterScreen, {
+      capture: true,
+    });
+    off('pointerout', onLeaveScreen, {
+      capture: true,
+    });
+    off('longpress', onInspect, {
+      capture: true,
+    });
+    off('quickexit', onExitInspect, {
+      capture: true,
+    });
   }
 
   function onActiveElement(e: PointerEvent) {
@@ -115,7 +144,7 @@ export function setupListeners(opts: SetupListenersOptions) {
 
     const el = <HTMLElement>e.target;
     if (checkClickedElement(el)) {
-      const targetEl = activeEl && checkVisibility(activeEl) ? activeEl : el;
+      const targetEl = activeEl?.isConnected ? activeEl : el;
       if (once) onExitInspect();
       onChangeElement(null);
       if (e.metaKey || e.type === 'longpress') {

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -52,6 +52,12 @@ interface Options {
    */
   colorMode?: 'system' | 'light' | 'dark';
   /**
+   * Disable hover effect from CSS when inspector is enabled
+   *
+   * @default false
+   */
+  disableHoverCSS?: boolean;
+  /**
    * exit the check after opening the editor or component tree
    *
    * @default true

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -24,6 +24,12 @@ export interface Options {
    */
   colorMode?: 'system' | 'light' | 'dark';
   /**
+   * Disable hover effect from CSS when inspector is enabled
+   *
+   * @default false
+   */
+  disableHoverCSS?: boolean;
+  /**
    * exit the check after opening the editor or component tree
    *
    * @default true

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -52,6 +52,12 @@ interface Options {
    */
   colorMode?: 'system' | 'light' | 'dark';
   /**
+   * Disable hover effect from CSS when inspector is enabled
+   *
+   * @default false
+   */
+  disableHoverCSS?: boolean;
+  /**
    * exit the check after opening the editor or component tree
    *
    * @default true

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -24,6 +24,12 @@ export interface Options {
    */
   colorMode?: 'system' | 'light' | 'dark';
   /**
+   * Disable hover effect from CSS when inspector is enabled
+   *
+   * @default false
+   */
+  disableHoverCSS?: boolean;
+  /**
    * exit the check after opening the editor or component tree
    *
    * @default true
@@ -49,6 +55,7 @@ export default function openEditorPlugin(
     rootDir = process.cwd(),
     displayToggle,
     colorMode,
+    disableHoverCSS,
     once,
     onOpenEditor,
   } = options;
@@ -61,6 +68,7 @@ export default function openEditorPlugin(
       rootDir,
       displayToggle,
       colorMode,
+      disableHoverCSS,
       once,
     },
     true,

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -52,6 +52,12 @@ interface Options {
    */
   colorMode?: 'system' | 'light' | 'dark';
   /**
+   * Disable hover effect from CSS when inspector is enabled
+   *
+   * @default false
+   */
+  disableHoverCSS?: boolean;
+  /**
    * exit the check after opening the editor or component tree
    *
    * @default true

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -23,6 +23,12 @@ export interface Options {
    */
   colorMode?: 'system' | 'light' | 'dark';
   /**
+   * Disable hover effect from CSS when inspector is enabled
+   *
+   * @default false
+   */
+  disableHoverCSS?: boolean;
+  /**
    * exit the check after opening the editor or component tree
    *
    * @default true


### PR DESCRIPTION
Support for disabling CSS hover effects when the inspector is enabled.
