### PR TITLE
chore: Improve rendering performance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,8 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "@typescript-eslint/no-explicit-any": 0,
-    "@typescript-eslint/ban-ts-comment": 0
+    "@typescript-eslint/ban-ts-comment": 0,
+    "@typescript-eslint/ban-types": 0,
+    "no-inner-declarations": 0
   }
 }

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -6,4 +6,4 @@ export const InternalElements = <const>{
   HTML_TREE_ELEMENT: 'oe-tree',
 };
 
-export const CACHE_POS_TOP_ID = '__oe_pt__';
+export const CACHE_POS_TOP_ID = '__oe_pt';

--- a/packages/client/src/elements/HTMLInspectElement/clickedElement.ts
+++ b/packages/client/src/elements/HTMLInspectElement/clickedElement.ts
@@ -12,11 +12,11 @@ export function setupClickedElementAttrs(e: Event) {
     resetAttrs(el, {
       disabled: {
         from: 'disabled',
-        to: '__disabled__',
+        to: '__disabled',
       },
       href: {
         from: 'href',
-        to: '__href__',
+        to: '__href',
       },
     });
 
@@ -28,11 +28,11 @@ export function cleanClickedElementAttrs() {
   if (clickedEl) {
     resetAttrs(clickedEl, {
       disabled: {
-        from: '__disabled__',
+        from: '__disabled',
         to: 'disabled',
       },
       href: {
-        from: '__href__',
+        from: '__href',
         to: 'href',
       },
     });

--- a/packages/client/src/elements/HTMLInspectElement/getColorMode.ts
+++ b/packages/client/src/elements/HTMLInspectElement/getColorMode.ts
@@ -16,7 +16,7 @@ const DarkColors = postcss`
   --text-color: #ffffff;
   --text-color2: #dddddd;
   --bg-color: #2c2c2e;
-  --bg-color-opt: #2c2c2ecc;
+  --bg-color-opt: #2c2c2ed9;
   --bg-color2: #6c6c6e;
   --cyan: #4df9fa;
 }

--- a/packages/client/src/elements/HTMLInspectElement/setupListeners.ts
+++ b/packages/client/src/elements/HTMLInspectElement/setupListeners.ts
@@ -178,8 +178,10 @@ function withEventFn<T extends (...args: any[]) => any>(fn: T) {
 
 function onSilent(e: Event) {
   // No action is expected on the event when target or relatedTarget is an invalid element.
-  const el: HTMLElement = (<any>e).relatedTarget ?? e.target;
-  if (checkValidElement(el)) {
+  if (
+    checkValidElement((<any>e).target) ||
+    checkValidElement((<any>e).relatedTarget)
+  ) {
     // [Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive.
     // Only need to handle touch events, excluding other events such as pointer
     // See https://www.chromestatus.com/feature/5093566007214080.

--- a/packages/client/src/elements/HTMLToggleElement/index.css
+++ b/packages/client/src/elements/HTMLToggleElement/index.css
@@ -44,7 +44,7 @@
   display: block;
 }
 .oe-dnd .oe-button {
-  transform: scale(1.1);
+  transform: scale(1.2);
   opacity: 0.8;
   cursor: ns-resize;
 }

--- a/packages/client/src/elements/HTMLTooltipElement/index.css
+++ b/packages/client/src/elements/HTMLTooltipElement/index.css
@@ -21,7 +21,7 @@
 }
 .oe-comp {
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-color);
 }
 .oe-file {

--- a/packages/client/src/elements/HTMLTreeElement/index.css
+++ b/packages/client/src/elements/HTMLTreeElement/index.css
@@ -1,6 +1,7 @@
 :host {
+  --min-w: 280px;
   --w: min(calc(100vw - 96px), 500px);
-  --h: min(calc(100vh - 148px), 600px);
+  --h: min(calc(100vh - 148px), 300px);
 }
 .oe-root {
   display: none;
@@ -53,8 +54,19 @@
 .oe-error .oe-close:hover {
   background: var(--red-light);
 }
+.oe-title {
+  min-width: var(--min-w);
+  max-width: var(--w);
+  padding: 0 12px 12px 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+.oe-tag {
+  font-size: 14px;
+  font-weight: 400;
+}
 .oe-content {
-  min-width: 220px;
+  min-width: var(--min-w);
   max-width: var(--w);
   max-height: var(--h);
   white-space: nowrap;
@@ -66,18 +78,6 @@
 }
 .oe-content > .oe-tree {
   margin-left: -10px;
-}
-.oe-title {
-  min-width: 220px;
-  max-width: var(--w);
-  max-height: var(--h);
-  padding: 0 16px 14px 0;
-  font-size: 18px;
-  font-weight: 500;
-}
-.oe-tag {
-  font-size: 14px;
-  font-weight: 400;
 }
 .oe-tree {
   position: relative;

--- a/packages/client/src/utils/SafeAreaObserver.ts
+++ b/packages/client/src/utils/SafeAreaObserver.ts
@@ -55,7 +55,7 @@ const style = globalStyle(postcss`
   --sail: env(safe-area-inset-left);
 }
 `);
-export function updateValue() {
+function updateValue() {
   style.mount();
   const get = computedStyle(document.body);
   value = {

--- a/packages/client/src/utils/openEditor.ts
+++ b/packages/client/src/utils/openEditor.ts
@@ -11,7 +11,7 @@ export async function openEditor(
   source: SourceCodeMeta,
   dispatch: (e: CustomEvent<URL>) => boolean,
 ) {
-  const { protocol, hostname, port } = window.location;
+  const { protocol, hostname, port } = location;
   const { file, line = 1, column = 1 } = source;
   const { port: customPort } = getOptions();
 

--- a/packages/client/src/utils/ui/dom.ts
+++ b/packages/client/src/utils/ui/dom.ts
@@ -2,23 +2,27 @@ import { Fragment } from '../../../jsx/jsx-runtime';
 import { InternalElements } from '../../constants';
 import { computedStyle } from './style';
 
-const internals: string[] = Object.values(InternalElements);
+const internals = Object.values(InternalElements).map((internal) =>
+  internal.toUpperCase(),
+);
 export function checkInternalElement(
   el: HTMLElement | null,
 ): el is HTMLElement {
-  return el != null && internals.includes(el.localName);
+  return el != null && internals.includes(el.nodeName);
 }
 
-const invalids: string[] = [
+const invalids = [
   ...internals,
+  // In Firefox, when the mouse leaves the visual area, the event target is `HTMLDocument`.
+  '#document',
   // The `html` check is triggered when the mouse leaves the browser,
   // and filtering is needed to ignore this unexpected check.
-  'html',
+  'HTML',
   // `iframe` should be left to the internal inspector.
-  'iframe',
+  'IFRAME',
 ];
 export function checkValidElement(el: HTMLElement | null): el is HTMLElement {
-  return el != null && el.isConnected && !invalids.includes(el.localName);
+  return el != null && el.isConnected && !invalids.includes(el.nodeName);
 }
 
 export function getHtml() {

--- a/packages/client/src/utils/ui/style.tsx
+++ b/packages/client/src/utils/ui/style.tsx
@@ -19,7 +19,7 @@ export function applyStyle(
 }
 
 export function computedStyle(el: HTMLElement) {
-  const style = window.getComputedStyle(el, null);
+  const style = getComputedStyle(el, null);
   // @ts-ignore
   function get(property: string): number;
   function get(property: string, toNumber: boolean): number | string;


### PR DESCRIPTION
Maintain a rendering speed of 60 frames per second to avoid rendering flickers caused by moving the mouse quickly on a high refresh rate screen.