### PR TITLE
feat: Make the style loaded through link lose the hover effect

### DIFF
--- a/.changeset/tidy-baboons-check.md
+++ b/.changeset/tidy-baboons-check.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Make the style loaded through link lose the hover effect

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "packages/*"
   ],
   "type": "module",
-  "description": "A web devtools for fast find source code.",
+  "description": "🚀 A web devtools for fast find source code.",
   "scripts": {
     "build": "concurrently --success all -r -m 1 'turbo run build --filter @open-editor/* --log-order grouped'",
     "clean": "rimraf -g {packages/**/.turbo,node_modules/.cache}",

--- a/packages/client/jsx/jsx-runtime.d.ts
+++ b/packages/client/jsx/jsx-runtime.d.ts
@@ -4,6 +4,9 @@ declare type UnionCharacter<T extends string> = T extends `${infer F}${infer R}`
 
 declare type UppercaseLetter = UnionCharacter<'ABCDEFGHIJKLMNOPQRSTUVWXYZ'>;
 
+declare type NativeElement<P> =
+  P extends React.DetailedHTMLProps<infer _, infer T> ? T : HTMLElement;
+
 declare type EventKey<K extends string> = K extends `on${infer F}${infer _}`
   ? F extends UppercaseLetter
     ? true
@@ -16,32 +19,7 @@ declare type EventType<K extends string> = K extends `on${infer F}`
 
 declare type NativeEvent<K extends string> = HTMLElementEventMap[EventType<K>];
 
-declare type CustomNode =
-  | HTMLElement
-  | string
-  | number
-  | false
-  | null
-  | undefined;
-
-declare type CustomProperty<P> = {
-  [K in keyof P]: K extends 'children'
-    ? CustomNode[]
-    : K extends 'ref'
-      ? (el: HTMLElement) => void
-      : EventKey<K> extends true
-        ? (e: NativeEvent<K>) => void
-        : P[K];
-} & {
-  onLongPress?(e: PointerEvent): void;
-  onQuickExit?(e: PointerEvent): void;
-};
-
-declare type CustomPropertyElements<ES> = {
-  [E in keyof ES]: CustomProperty<ES[E]>;
-};
-
-declare interface InternalCustomElements {
+declare type InternalCustomElements = {
   'o-e-inspect': React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLInspectElement>,
     HTMLInspectElement
@@ -62,11 +40,30 @@ declare interface InternalCustomElements {
     React.HTMLAttributes<HTMLTreeElement>,
     HTMLTreeElement
   >;
-}
+};
+
+declare type _Node = HTMLElement | string | number | false | null | undefined;
+
+declare type _Element<P> = {
+  [K in keyof P]: K extends 'children'
+    ? _Node[]
+    : K extends 'ref'
+      ? (el: NativeElement<P>) => void
+      : EventKey<K> extends true
+        ? (e: NativeEvent<K>) => void
+        : P[K];
+} & {
+  onLongPress?(e: PointerEvent): void;
+  onQuickExit?(e: PointerEvent): void;
+};
+
+declare type _IntrinsicElements<ES> = {
+  [E in keyof ES]: _Element<ES[E]>;
+};
 
 declare namespace _JSX {
   type Element = HTMLElement;
-  type IntrinsicElements = CustomPropertyElements<
+  type IntrinsicElements = _IntrinsicElements<
     JSX.IntrinsicElements & InternalCustomElements
   >;
 }

--- a/packages/client/src/elements/HTMLInspectElement/index.tsx
+++ b/packages/client/src/elements/HTMLInspectElement/index.tsx
@@ -64,10 +64,10 @@ export class HTMLInspectElement extends HTMLCustomElement<{
         <link rel="stylesheet" href="./index.css" />
         <style type="text/css">{getColorMode()}</style>
         <InternalElements.HTML_OVERLAY_ELEMENT
-          ref={(el) => (this.state.overlay = el as HTMLOverlayElement)}
+          ref={(el) => (this.state.overlay = el)}
         />
         <InternalElements.HTML_TREE_ELEMENT
-          ref={(el) => (this.state.tree = el as HTMLTreeElement)}
+          ref={(el) => (this.state.tree = el)}
         />
         {opts.displayToggle && (
           <InternalElements.HTML_TOGGLE_ELEMENT

--- a/packages/client/src/elements/HTMLOverlayElement/index.tsx
+++ b/packages/client/src/elements/HTMLOverlayElement/index.tsx
@@ -65,7 +65,7 @@ export class HTMLOverlayElement extends HTMLCustomElement<{
           </div>
         </div>
         <InternalElements.HTML_TOOLTIP_ELEMENT
-          ref={(el) => (this.state.tooltip = el as HTMLTooltipElement)}
+          ref={(el) => (this.state.tooltip = el)}
         />
       </>
     );


### PR DESCRIPTION
Simply modifying the content of the style tag cannot completely block the hover effect, and styles loaded through links cannot be blocked.

Now we will also block the styles loaded through the link by modifying cssRule.