### PR TITLE
feat: Allow HTTPS server to run by adding configuration

### DIFF
--- a/.changeset/mighty-socks-shake.md
+++ b/.changeset/mighty-socks-shake.md
@@ -1,0 +1,6 @@
+---
+'@open-editor/webpack': patch
+'@open-editor/rollup': patch
+---
+
+Add `server` configuration

--- a/.changeset/rich-boxes-sort.md
+++ b/.changeset/rich-boxes-sort.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/server': patch
+---
+
+Allow HTTPS server to run by adding configuration

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -50,6 +50,20 @@ export interface Options {
    */
   once?: boolean;
   /**
+   * Internal server configuration
+   */
+  server?: {
+    /**
+     * enable https
+     *
+     * @see https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
+     */
+    https?: {
+      key: string;
+      cert: string;
+    };
+  };
+  /**
    * custom openEditor handler
    *
    * @default 'launch-editor'
@@ -93,6 +107,7 @@ export default function OpenEditorPlugin(
     async buildStart() {
       const cacheKey = `${rootDir}${onOpenEditor}`;
       port = await (portPromiseCache[cacheKey] ||= setupServer({
+        ...(options.server ?? {}),
         rootDir,
         onOpenEditor,
       }));

--- a/packages/server/src/setupServer.ts
+++ b/packages/server/src/setupServer.ts
@@ -1,4 +1,6 @@
 import http from 'node:http';
+import https from 'node:https';
+import { readFileSync } from 'node:fs';
 import { createApp } from './createApp';
 
 export interface Options {
@@ -9,6 +11,15 @@ export interface Options {
    */
   rootDir?: string;
   /**
+   * enable https
+   *
+   * @see https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
+   */
+  https?: {
+    key: string;
+    cert: string;
+  };
+  /**
    * custom openEditor handler
    *
    * @default 'launch-editor'
@@ -17,12 +28,20 @@ export interface Options {
 }
 
 export function setupServer(options: Options = {}) {
-  const { rootDir } = options;
+  const { rootDir, https: httpsOpts } = options;
 
   const app = createApp({
     rootDir,
   });
-  const httpServer = http.createServer(app);
+  const httpServer = httpsOpts
+    ? https.createServer(
+        {
+          key: readFileSync(httpsOpts.key),
+          cert: readFileSync(httpsOpts.cert),
+        },
+        app,
+      )
+    : http.createServer(app);
   return startServer(httpServer);
 }
 

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -49,6 +49,20 @@ export interface Options {
    */
   once?: boolean;
   /**
+   * Internal server configuration
+   */
+  server?: {
+    /**
+     * enable https
+     *
+     * @see https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
+     */
+    https?: {
+      key: string;
+      cert: string;
+    };
+  };
+  /**
    * custom openEditor handler
    *
    * @default 'launch-editor'
@@ -165,9 +179,10 @@ export default class OpenEditorPlugin {
   setupServer() {
     this.compiler.hooks.make.tapPromise(PLUGIN_NAME, async () => {
       const cacheKey = `${this.options.rootDir}${this.options.onOpenEditor}`;
-      this.options.port = await (portPromiseCache[cacheKey] ||= setupServer(
-        this.options,
-      ));
+      this.options.port = await (portPromiseCache[cacheKey] ||= setupServer({
+        ...this.options,
+        ...(this.options.server ?? {}),
+      }));
     });
   }
 }


### PR DESCRIPTION
Allow HTTPS server to run by adding configuration

```ts
OpenEditor({
  server: {
    https: {
      key: './test/fixtures/keys/agent2-key.pem',
      cert: './test/fixtures/keys/agent2-cert.pem',
    },
  },
});
```