### PR TITLE
fix: DOMRect error in Firefox

### DIFF
--- a/.changeset/gold-rockets-tap.md
+++ b/.changeset/gold-rockets-tap.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Fix DOMRect error in Firefox

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 🚀🚀🚀 A web devtools for fast find source code.
 
-Whether you are a `React` developer, a `Vue` developer, or a `React` and `Vue` developer, this development tool can help you. It can save you a lot of time looking for code, allowing you to focus more on writing code. Whether in `React` or `Vue`, it can achieve exactly the same effect.
+Whether you are a `React` developer, a `Vue` developer, or a developer who uses both `React` and `Vue`, this development tool can help you. It can save you a lot of time searching for code and allow you to focus more on writing code. It can achieve the same effect in both `React` and `Vue`.
 
 ![image](./public/demo.gif)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,16 +55,8 @@
 
 首先需要将插件安装到项目中。
 
-- 插件
-
 ```bash
 npm i @open-editor/vite -D
-```
-
-- 客户端
-
-```bash
-npm i @open-editor/client
 ```
 
 然后将插件添加到编译配置中。

--- a/packages/client/src/utils/dom.tsx
+++ b/packages/client/src/utils/dom.tsx
@@ -28,17 +28,25 @@ export function getHtml() {
   return document.documentElement;
 }
 
-export function getDOMRect(target: HTMLElement): Omit<DOMRect, 'toJSON'> {
+const withZoom =
+  CLIENT && 'zoom' in getHtml().style && !/firefox/i.test(navigator.userAgent);
+export function getDOMRect(
+  target: HTMLElement,
+): Omit<DOMRectReadOnly, 'toJSON'> {
   const domRect = target.getBoundingClientRect().toJSON();
+  if (withZoom) {
+    return computeDOMRect(target, domRect);
+  }
+  return domRect;
+}
 
+function computeDOMRect(target: HTMLElement, domRect: DOMRect) {
   let zoom = 1;
   while (target) {
     zoom *= computedStyle(target)('zoom');
     target = target.parentElement!;
   }
-
-  // In browsers that do not support zoom, zoom is always empty.
-  if (zoom !== 0 && zoom !== 1) {
+  if (zoom !== 1) {
     Object.keys(domRect).forEach((key) => (domRect[key] *= zoom));
   }
   return domRect;


### PR DESCRIPTION
Get the DOMRect with Zoom style elements in Firefox. DOMRect is the value calculated with Zoom, so there is no need to recalculate.