### PR TITLE
fix: disableHoverCSS effect on atom css

### DIFF
--- a/.changeset/fluffy-days-switch.md
+++ b/.changeset/fluffy-days-switch.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Fix disableHoverCSS effect on atom css

--- a/packages/client/src/elements/utils/disableHoverCSS.ts
+++ b/packages/client/src/elements/utils/disableHoverCSS.ts
@@ -1,7 +1,7 @@
 const DISABLE_RE = /:hover/g;
-const DISABLE_TOKEN = '::hover';
+const DISABLE_TOKEN = ':oe-disable-hover';
 
-const ENABLE_RE = /:+:hover/g;
+const ENABLE_RE = /:oe-disable-hover/g;
 const ENABLE_TOKEN = ':hover';
 
 export function disableHoverCSS() {


### PR DESCRIPTION
Fixed the problem that disableHoverCSS caused some classes to fail in tailwindcss