### PR TITLE
fix: click event penetration

### DIFF
--- a/.changeset/bright-jokes-kiss.md
+++ b/.changeset/bright-jokes-kiss.md
@@ -1,0 +1,5 @@
+---
+'@open-editor/client': patch
+---
+
+Fix click event penetration

--- a/packages/client/src/bridge/treeOpenBridge.tsx
+++ b/packages/client/src/bridge/treeOpenBridge.tsx
@@ -1,8 +1,18 @@
 import { crossIframeBridge } from '../utils/crossIframeBridge';
 import { isTopWindow, whenTopWindow } from '../utils/topWindow';
+import { appendChild } from '../utils/dom';
 import { onMessage, postMessage } from '../utils/message';
 import { resolveSource, type CodeSource } from '../resolve';
 import { TREE_OPEN_CROSS_IFRAME } from '../constants';
+
+const preventEventOverlay = (
+  <div
+    className="oe-prevent-event-overlay"
+    onPointerMove={() => preventEventOverlay.remove()}
+    onPointerUp={() => preventEventOverlay.remove()}
+    onPointerCancel={() => preventEventOverlay.remove()}
+  />
+);
 
 export const treeOpenBridge = crossIframeBridge<[CodeSource]>({
   setup() {
@@ -11,6 +21,10 @@ export const treeOpenBridge = crossIframeBridge<[CodeSource]>({
     });
   },
   emitMiddlewares: [
+    (_, next) => {
+      appendChild(document.body, preventEventOverlay);
+      next();
+    },
     ([source], next) => {
       if (window.frameElement) {
         const { tree } = resolveSource(window.frameElement as HTMLElement, true);

--- a/packages/client/src/inspector/globalStyles.ts
+++ b/packages/client/src/inspector/globalStyles.ts
@@ -17,5 +17,14 @@ const effectCSS = css`
   .oe-loading * {
     cursor: wait !important;
   }
+  .oe-prevent-event-overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    opacity: 0;
+    z-index: 2147483647;
+  }
 `;
 export const effectStyle = createGlobalStyle(effectCSS);

--- a/packages/client/src/inspector/index.ts
+++ b/packages/client/src/inspector/index.ts
@@ -1,4 +1,4 @@
-import { addClass, getHtml, removeClass } from '../utils/dom';
+import { addClass, removeClass } from '../utils/dom';
 import { on } from '../event';
 import { CURRENT_INSPECT_ID } from '../constants';
 import {
@@ -47,6 +47,6 @@ export function setupInspector() {
   inspectorEnableBridge.on(inspectorEnable);
   inspectorExitBridge.on(inspectorExit);
   openEditorBridge.on(openEditor);
-  openEditorStartBridge.on(() => addClass(getHtml(), 'oe-loading'));
-  openEditorEndBridge.on(() => removeClass(getHtml(), 'oe-loading'));
+  openEditorStartBridge.on(() => addClass(document.body, 'oe-loading'));
+  openEditorEndBridge.on(() => removeClass(document.body, 'oe-loading'));
 }

--- a/packages/client/src/ui/ToggleUI.tsx
+++ b/packages/client/src/ui/ToggleUI.tsx
@@ -1,5 +1,5 @@
 import { clamp } from '@open-editor/shared';
-import { getHtml, CSS_util, applyStyle, addClass, removeClass } from '../utils/dom';
+import { CSS_util, applyStyle, addClass, removeClass } from '../utils/dom';
 import { safeArea, safeAreaObserver } from '../utils/safeArea';
 import { inspectorState } from '../inspector/inspectorState';
 import { off, on } from '../event';
@@ -10,7 +10,6 @@ export function ToggleUI() {
     root: HTMLElement;
     button: HTMLElement;
     dnding: boolean;
-    active: boolean;
     touchable: boolean;
   };
 
@@ -74,7 +73,7 @@ export function ToggleUI() {
   }
 
   function updatePosTop() {
-    const { clientHeight: winH } = getHtml();
+    const { clientHeight: winH } = document.body;
     const { offsetHeight: toggleH } = state.root;
 
     const cachePosY = +localStorage['oe-pt'] || 0;

--- a/packages/client/src/ui/TooltipUI.tsx
+++ b/packages/client/src/ui/TooltipUI.tsx
@@ -1,6 +1,6 @@
 import { clamp } from '@open-editor/shared';
 import { mitt } from '../utils/mitt';
-import { getHtml, CSS_util, applyStyle, addClass, removeClass } from '../utils/dom';
+import { CSS_util, applyStyle, addClass, removeClass } from '../utils/dom';
 import { getDOMRect } from '../utils/getDOMRect';
 import { safeArea } from '../utils/safeArea';
 import { type BoxRect } from '../inspector/getBoxModel';
@@ -67,7 +67,7 @@ export function TooltipUI() {
       clientWidth: winW,
       // window height excluding the scrollbar height
       clientHeight: winH,
-    } = getHtml();
+    } = document.body;
     const { width: rootW, height: rootH } = getDOMRect(state.root);
 
     const onTopArea = rect.top > rootH + safeArea.top + OFFSET * 2;

--- a/packages/client/src/utils/dom.tsx
+++ b/packages/client/src/utils/dom.tsx
@@ -1,9 +1,5 @@
 import { Fragment } from '../../jsx/jsx-runtime';
 
-export function getHtml() {
-  return document.documentElement;
-}
-
 export function applyAttrs(el: HTMLElement, attrs: AnyObject) {
   for (const prop of Object.keys(attrs)) {
     const val = attrs[prop];

--- a/packages/client/src/utils/getDOMRect.ts
+++ b/packages/client/src/utils/getDOMRect.ts
@@ -1,5 +1,6 @@
+import { hasOwnProperty } from '@open-editor/shared';
 import { IS_CLIENT, IS_FIREFOX } from '../constants';
-import { computedStyle, getHtml } from './dom';
+import { computedStyle } from './dom';
 
 /**
  * In most browsers, the return value of [getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)
@@ -9,7 +10,7 @@ import { computedStyle, getHtml } from './dom';
  */
 const IS_COMPUTED =
   IS_CLIENT &&
-  'zoom' in getHtml().style &&
+  hasOwnProperty(document.body.style, 'zoom') &&
   // Firefox does not need to calculate
   !IS_FIREFOX &&
   // Chromium version greater than 127 do not need to be calculated


### PR DESCRIPTION
When opening the tree in an iframe, the inspected element triggers a click event, which is unexpected. Now the mask element swallows the unexpected click event to make the interaction intuitive.